### PR TITLE
Add Quadtree broad-phase + split RE-Sim into Grid / Quadtree modes

### DIFF
--- a/client/plugins/auto-dodge.ts
+++ b/client/plugins/auto-dodge.ts
@@ -2,11 +2,12 @@ import type { PluginContext } from '../src/plugins/PluginContext.js';
 import { sendDllFeature } from '../src/bridge/DllFeatureBus.js';
 
 // Maps the dashboard string value to the C++ TestTAB::DodgeMode enum.
-// Off=0, XDodge=1, Rollout=2.
+// Off=0, XDodge=1, RolloutGrid=2, RolloutQuad=3.
 // XDodge uses A* (goal-directed) with BFS fallback (immediate escape),
-// ported from XRebuild/XDriver decompile. Rollout (RE-Sim) does per-input
-// forward simulation against a uniform-grid broad-phase.
-const DODGE_VALUES = ['off', 'xdodge', 'rollout'] as const;
+// ported from XRebuild/XDriver decompile. RE-Sim does per-input forward
+// simulation; the two RE-Sim modes differ only in broad-phase backend
+// (grid vs quadtree) so they can be A/B-compared.
+const DODGE_VALUES = ['off', 'xdodge', 'rollout-grid', 'rollout-quad'] as const;
 
 function modeToIdx(v: string): number {
   const i = DODGE_VALUES.indexOf(v as (typeof DODGE_VALUES)[number]);
@@ -29,7 +30,8 @@ export function register(ctx: PluginContext) {
     options: [
       { label: 'Off', value: 'off' },
       { label: 'RE-Plus', value: 'xdodge' },
-      { label: 'RE-Sim', value: 'rollout' },
+      { label: 'RE-Sim (Grid)', value: 'rollout-grid' },
+      { label: 'RE-Sim (Quadtree)', value: 'rollout-quad' },
     ],
   }, () => flush());
 
@@ -226,8 +228,6 @@ export function register(ctx: PluginContext) {
     (v: string) => sendDllFeature('rolloutWasdYield', v === 'on' ? 1 : 0));
   ctx.registerSetting('rolloutCommitDwell', onOff('[RE-Sim] Commit dwell (no direction flip-flop)'),
     (v: string) => sendDllFeature('rolloutCommitDwell', v === 'on' ? 1 : 0));
-  ctx.registerSetting('rolloutForceBrute', onOff('[RE-Sim] Force brute-force broad-phase (debug)', 'off'),
-    (v: string) => sendDllFeature('rolloutForceBrute', v === 'on' ? 1 : 0));
   ctx.registerSetting('rolloutDrawPath', onOff('[RE-Sim] Draw candidate rollouts (debug)', 'off'),
     (v: string) => sendDllFeature('rolloutDrawPath', v === 'on' ? 1 : 0));
 
@@ -255,7 +255,7 @@ export function register(ctx: PluginContext) {
     sendDllFeature('rolloutHitScale',      ctx.getSetting<number>('rolloutHitScale'));
     sendDllFeature('rolloutIntentWeight',  ctx.getSetting<number>('rolloutIntentWeight'));
     sendDllFeature('rolloutRebuildN',      ctx.getSetting<number>('rolloutRebuildN'));
-    for (const k of ['rolloutAvoidEnemies', 'rolloutWasdYield', 'rolloutCommitDwell', 'rolloutForceBrute', 'rolloutDrawPath'])
+    for (const k of ['rolloutAvoidEnemies', 'rolloutWasdYield', 'rolloutCommitDwell', 'rolloutDrawPath'])
       sendDllFeature(k, ctx.getSetting<string>(k) === 'on' ? 1 : 0);
     // Re-apply the 60fps cap here too. The onEnabledChange / clientConnected
     // handlers were the only places setting targetFrameRate, so if the cap

--- a/internal/il2cpp-dll-injection.vcxproj
+++ b/internal/il2cpp-dll-injection.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="src\features\movement\dodge\DangerPlanner.cpp" />
     <ClCompile Include="src\features\movement\dodge\RolloutDodge.cpp" />
     <ClCompile Include="src\features\movement\dodge\GridThreatIndex.cpp" />
+    <ClCompile Include="src\features\movement\dodge\QuadtreeThreatIndex.cpp" />
     <ClCompile Include="src\features\movement\dodge\MovementRuntime.cpp" />
     <ClCompile Include="src\features\movement\dodge\ProjectileCatalog.cpp" />
     <ClCompile Include="src\features\movement\dodge\SteerInput.cpp" />
@@ -183,6 +184,7 @@
     <ClInclude Include="src\features\movement\dodge\RolloutDodge.h" />
     <ClInclude Include="src\features\movement\dodge\ThreatIndex.h" />
     <ClInclude Include="src\features\movement\dodge\GridThreatIndex.h" />
+    <ClInclude Include="src\features\movement\dodge\QuadtreeThreatIndex.h" />
     <ClInclude Include="src\features\movement\dodge\DodgeHit.h" />
     <ClInclude Include="src\features\movement\dodge\DodgeSpeed.h" />
     <ClInclude Include="src\features\movement\dodge\DodgeGeometry.h" />

--- a/internal/il2cpp-dll-injection.vcxproj.filters
+++ b/internal/il2cpp-dll-injection.vcxproj.filters
@@ -21,6 +21,7 @@
     <ClCompile Include="src\features\movement\dodge\DangerPlanner.cpp" />
     <ClCompile Include="src\features\movement\dodge\RolloutDodge.cpp" />
     <ClCompile Include="src\features\movement\dodge\GridThreatIndex.cpp" />
+    <ClCompile Include="src\features\movement\dodge\QuadtreeThreatIndex.cpp" />
     <ClCompile Include="src\features\movement\dodge\MovementRuntime.cpp" />
     <ClCompile Include="src\features\movement\dodge\ProjectileCatalog.cpp" />
     <ClCompile Include="src\features\movement\dodge\SteerInput.cpp" />
@@ -110,6 +111,7 @@
     <ClInclude Include="src\features\movement\dodge\RolloutDodge.h" />
     <ClInclude Include="src\features\movement\dodge\ThreatIndex.h" />
     <ClInclude Include="src\features\movement\dodge\GridThreatIndex.h" />
+    <ClInclude Include="src\features\movement\dodge\QuadtreeThreatIndex.h" />
     <ClInclude Include="src\features\movement\dodge\DodgeHit.h" />
     <ClInclude Include="src\features\movement\dodge\DodgeSpeed.h" />
     <ClInclude Include="src\features\movement\dodge\DodgeGeometry.h" />

--- a/internal/src/features/movement/dodge/QuadtreeThreatIndex.cpp
+++ b/internal/src/features/movement/dodge/QuadtreeThreatIndex.cpp
@@ -1,0 +1,97 @@
+#include "pch-il2cpp.h"
+#include "QuadtreeThreatIndex.h"
+
+#include <algorithm>
+
+namespace Threats {
+
+namespace {
+constexpr int kMaxDepth = 8;   // subdivision cap (deep enough for tile-scale items)
+}
+
+int QuadtreeThreatIndex::AllocNode(const Aabb& b)
+{
+    const int i = m_nodeCount++;
+    if (i >= static_cast<int>(m_nodes.size())) m_nodes.resize(i + 1);
+    Node& n = m_nodes[i];
+    n.bounds = b;
+    n.child[0] = n.child[1] = n.child[2] = n.child[3] = -1;
+    n.items.clear();           // keeps capacity across rebuilds
+    return i;
+}
+
+// Descend from nodeIdx, placing idx in the deepest node whose quadrant fully
+// contains box. Iterative so we never hold a Node& across AllocNode (which may
+// reallocate the pool and invalidate references).
+void QuadtreeThreatIndex::Insert(int nodeIdx, const Aabb& box, int idx, int depth)
+{
+    for (;;) {
+        if (depth >= kMaxDepth) { m_nodes[nodeIdx].items.push_back(idx); return; }
+        const Aabb  b    = m_nodes[nodeIdx].bounds;     // copy — no dangling ref
+        const float midX = 0.5f * (b.minX + b.maxX);
+        const float midY = 0.5f * (b.minY + b.maxY);
+        const bool  left   = box.maxX <= midX;
+        const bool  right  = box.minX >= midX;
+        const bool  bottom = box.maxY <= midY;
+        const bool  top    = box.minY >= midY;
+        if (!((left || right) && (bottom || top))) {    // straddles a split line
+            m_nodes[nodeIdx].items.push_back(idx);
+            return;
+        }
+        const int qx = right ? 1 : 0;
+        const int qy = top   ? 1 : 0;
+        const int q  = qy * 2 + qx;
+        int c = m_nodes[nodeIdx].child[q];
+        if (c == -1) {
+            Aabb cb;
+            cb.minX = qx ? midX : b.minX; cb.maxX = qx ? b.maxX : midX;
+            cb.minY = qy ? midY : b.minY; cb.maxY = qy ? b.maxY : midY;
+            c = AllocNode(cb);                          // may reallocate m_nodes
+            m_nodes[nodeIdx].child[q] = c;              // re-index after alloc
+        }
+        nodeIdx = c; ++depth;                           // descend
+    }
+}
+
+void QuadtreeThreatIndex::Build(const std::vector<Threat>& threats)
+{
+    m_threats = &threats;
+    m_nodeCount = 0;
+    const int n = static_cast<int>(threats.size());
+    if (n == 0) return;
+
+    float minX = threats[0].box.minX, minY = threats[0].box.minY;
+    float maxX = threats[0].box.maxX, maxY = threats[0].box.maxY;
+    for (int i = 1; i < n; ++i) {
+        const Aabb& b = threats[i].box;
+        minX = std::min(minX, b.minX); minY = std::min(minY, b.minY);
+        maxX = std::max(maxX, b.maxX); maxY = std::max(maxY, b.maxY);
+    }
+    // Guard a degenerate (zero-area) root so split midpoints stay finite.
+    if (maxX <= minX) maxX = minX + 1.f;
+    if (maxY <= minY) maxY = minY + 1.f;
+
+    const int root = AllocNode(Aabb{ minX, minY, maxX, maxY });
+    for (int i = 0; i < n; ++i)
+        Insert(root, threats[i].box, i, 0);
+}
+
+void QuadtreeThreatIndex::QueryNode(int nodeIdx, const Aabb& region,
+                                    std::vector<int>& out) const
+{
+    const Node& n = m_nodes[nodeIdx];     // safe: Query never mutates the pool
+    if (!AabbOverlap(n.bounds, region)) return;
+    const std::vector<Threat>& th = *m_threats;
+    for (int idx : n.items)
+        if (AabbOverlap(th[idx].box, region)) out.push_back(idx);
+    for (int q = 0; q < 4; ++q)
+        if (n.child[q] != -1) QueryNode(n.child[q], region, out);
+}
+
+void QuadtreeThreatIndex::Query(const Aabb& region, std::vector<int>& out) const
+{
+    if (m_nodeCount == 0 || !m_threats) return;
+    QueryNode(0, region, out);
+}
+
+} // namespace Threats

--- a/internal/src/features/movement/dodge/QuadtreeThreatIndex.h
+++ b/internal/src/features/movement/dodge/QuadtreeThreatIndex.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "ThreatIndex.h"
+#include <vector>
+
+namespace Threats {
+
+// QuadtreeThreatIndex — self-contained region quadtree over the threats' swept
+// AABBs (no external deps; NOT supahero1's lib, which drags in a Linux-first
+// allocator). Provided as a SELECTABLE broad-phase so the rollout's grid and
+// quadtree backends can be A/B-compared in-game.
+//
+// Each threat is stored once, at the deepest node whose quadrant fully contains
+// its AABB (straddlers stay at the parent); Query() recurses the nodes
+// overlapping the region and rechecks exact AABB overlap. The node pool is
+// reused across rebuilds (no per-frame heap churn).
+//
+// On Realm's dense, dynamic, small-resolution field a uniform grid generally
+// wins (the per-rebuild tree build cost outweighs the query savings) — this
+// backend exists so that can be measured rather than assumed.
+class QuadtreeThreatIndex final : public ThreatIndex {
+public:
+    void Build(const std::vector<Threat>& threats) override;
+    void Query(const Aabb& region, std::vector<int>& out) const override;
+    const char* Name() const override { return "quad"; }
+
+private:
+    struct Node {
+        Aabb             bounds;
+        int              child[4];
+        std::vector<int> items;
+    };
+    const std::vector<Threat>* m_threats   = nullptr;
+    std::vector<Node>          m_nodes;        // pool, reused across builds
+    int                        m_nodeCount = 0;
+
+    int  AllocNode(const Aabb& b);
+    void Insert(int nodeIdx, const Aabb& box, int idx, int depth);
+    void QueryNode(int nodeIdx, const Aabb& region, std::vector<int>& out) const;
+};
+
+} // namespace Threats

--- a/internal/src/features/movement/dodge/RolloutDodge.cpp
+++ b/internal/src/features/movement/dodge/RolloutDodge.cpp
@@ -2,6 +2,7 @@
 #include "RolloutDodge.h"
 #include "ThreatIndex.h"
 #include "GridThreatIndex.h"
+#include "QuadtreeThreatIndex.h"
 #include "DodgeHit.h"
 #include "DodgeSpeed.h"
 #include "DangerPlanner.h"
@@ -34,6 +35,7 @@ using Threats::Aabb;
 using Threats::ThreatIndex;
 using Threats::BruteForceIndex;
 using Threats::GridThreatIndex;
+using Threats::QuadtreeThreatIndex;
 using Threats::kMaxThreatSamples;
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -61,7 +63,7 @@ std::atomic<int>   g_headingCount { 16 };
 std::atomic<float> g_hitScale     { 1.0f };
 std::atomic<float> g_intentWeight { 1.0f };
 std::atomic<int>   g_rebuildN     { 2 };
-std::atomic<bool>  g_forceBrute   { false };
+std::atomic<int>   g_broadPhase   { 0 };    // 0=Auto 1=Brute 2=Grid 3=Quad
 std::atomic<bool>  g_avoidEnemies { true };
 std::atomic<bool>  g_wasdYield    { true };
 std::atomic<bool>  g_commitDwell  { true };
@@ -71,6 +73,7 @@ std::atomic<bool>  g_drawPath     { false };
 std::vector<Threat> g_threats;
 BruteForceIndex     g_brute;
 GridThreatIndex     g_grid;
+QuadtreeThreatIndex g_quad;
 DodgeSpeed::ObsSpeed g_obs;
 
 int      g_frameCount = 0;
@@ -253,14 +256,17 @@ float RolloutInput(float px, float py, float dirX, float dirY, float reach,
 
 ThreatIndex* ChooseIndex(int threatCount)
 {
-    // Dense field ⇒ uniform grid (sublinear prune); sparse ⇒ brute-force AABB
-    // scan (the always-correct reference). force-brute-force pins brute.
-    if (!g_forceBrute.load(std::memory_order_relaxed) && threatCount >= kGridThreshold) {
-        g_lastBackend = "grid";
-        return &g_grid;
+    // Broad-phase selector (A/B). Explicit Brute / Grid / Quad pin a backend;
+    // Auto uses the uniform grid when the field is dense, else the brute-force
+    // AABB scan (the always-correct reference).
+    switch (g_broadPhase.load(std::memory_order_relaxed)) {
+        case 1: g_lastBackend = "brute"; return &g_brute;
+        case 2: g_lastBackend = "grid";  return &g_grid;
+        case 3: g_lastBackend = "quad";  return &g_quad;
+        default: break;   // Auto
     }
-    g_lastBackend = "brute";
-    return &g_brute;
+    if (threatCount >= kGridThreshold) { g_lastBackend = "grid"; return &g_grid; }
+    g_lastBackend = "brute"; return &g_brute;
 }
 
 // ── The planner: pick the best input this rebuild ─────────────────────────────
@@ -511,8 +517,7 @@ void RenderSettings()
     if (ImGui::Checkbox("Manual WASD yield##rl", &wy)) SetWasdYieldEnabled(wy);
     bool cd = g_commitDwell.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Commit dwell##rl", &cd)) SetCommitDwellEnabled(cd);
-    bool fb = g_forceBrute.load(std::memory_order_relaxed);
-    if (ImGui::Checkbox("Force brute-force broad-phase (debug)##rl", &fb)) SetForceBruteForce(fb);
+    ImGui::TextDisabled("Broad-phase: %s (set by the dodge mode)", g_lastBackend);
     bool dp = g_drawPath.load(std::memory_order_relaxed);
     if (ImGui::Checkbox("Draw candidate rollouts (debug)##rl", &dp)) SetDrawPathEnabled(dp);
 
@@ -536,8 +541,8 @@ void  SetIntentWeight(float w)  { g_intentWeight.store(std::clamp(w, 0.f, 3.0f),
 float GetIntentWeight()         { return g_intentWeight.load(std::memory_order_relaxed); }
 void  SetRebuildN(int n)        { g_rebuildN.store(std::clamp(n, 1, 10), std::memory_order_relaxed); }
 int   GetRebuildN()             { return g_rebuildN.load(std::memory_order_relaxed); }
-void  SetForceBruteForce(bool b){ g_forceBrute.store(b, std::memory_order_relaxed); }
-bool  GetForceBruteForce()      { return g_forceBrute.load(std::memory_order_relaxed); }
+void  SetBroadPhase(int m)      { g_broadPhase.store(std::clamp(m, 0, 3), std::memory_order_relaxed); }
+int   GetBroadPhase()           { return g_broadPhase.load(std::memory_order_relaxed); }
 void  SetAvoidEnemiesEnabled(bool e){ g_avoidEnemies.store(e, std::memory_order_relaxed); }
 bool  GetAvoidEnemiesEnabled()  { return g_avoidEnemies.load(std::memory_order_relaxed); }
 void  SetWasdYieldEnabled(bool e){ g_wasdYield.store(e, std::memory_order_relaxed); }

--- a/internal/src/features/movement/dodge/RolloutDodge.h
+++ b/internal/src/features/movement/dodge/RolloutDodge.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 
-// RolloutDodge — forward input-simulation dodge (DodgeMode::Rollout = 2).
+// RolloutDodge — forward input-simulation dodge (DodgeMode::RolloutGrid = 2 / RolloutQuad = 3).
 //
 // Instead of asking "is this cell occupied at time-slice t?" (XDodge's
 // discretized spacetime danger grid), this asks the direct question:
@@ -57,9 +57,11 @@ float GetIntentWeight();
 // re-issued each frame). 1..10, default 2.
 void  SetRebuildN(int n);
 int   GetRebuildN();
-// Debug: force the brute-force broad-phase (bypass the grid). Default off.
-void  SetForceBruteForce(bool on);
-bool  GetForceBruteForce();
+// Broad-phase backend selector (for A/B): 0 = Auto (grid when dense, else
+// brute-force), 1 = Brute-force, 2 = Grid, 3 = Quadtree. Default Auto. The
+// dodge mode (RolloutGrid / RolloutQuad) sets this on enter.
+void  SetBroadPhase(int mode);
+int   GetBroadPhase();
 // Never stand on enemy bodies (contact damage): stamp live enemies as static
 // threats so the rollout routes around them. Default on.
 void  SetAvoidEnemiesEnabled(bool en);

--- a/internal/src/ui/IpcBridge.cpp
+++ b/internal/src/ui/IpcBridge.cpp
@@ -236,8 +236,8 @@ void ApplyAutoDodgeFeatureState()
 
     int dodgeMode = s_featDodgeMode.load(std::memory_order_relaxed);
     if (dodgeMode < 0) dodgeMode = 0;
-    if (dodgeMode > static_cast<int>(TestTAB::DodgeMode::Rollout))
-        dodgeMode = static_cast<int>(TestTAB::DodgeMode::Rollout);
+    if (dodgeMode > static_cast<int>(TestTAB::DodgeMode::RolloutQuad))
+        dodgeMode = static_cast<int>(TestTAB::DodgeMode::RolloutQuad);
     if (dodgeMode != s_lastMode) {
         s_lastMode = dodgeMode;
         // Routes through TestTAB::ApplyDodgeModeWithEnter → DangerPlanner::TryInstall/SetEnabled.
@@ -493,8 +493,8 @@ int IpcBridge_GetAutoDodgeMode()
 void IpcBridge_SetAutoDodgeMode(int mode)
 {
     if (mode < 0) mode = 0;
-    if (mode > static_cast<int>(TestTAB::DodgeMode::Rollout))
-        mode = static_cast<int>(TestTAB::DodgeMode::Rollout);
+    if (mode > static_cast<int>(TestTAB::DodgeMode::RolloutQuad))
+        mode = static_cast<int>(TestTAB::DodgeMode::RolloutQuad);
     s_featDodgeMode.store(mode, std::memory_order_relaxed);
 }
 
@@ -1356,7 +1356,7 @@ static void DispatchCommand(char* json)
                    strcmp(keyBuf, "xdodgeFutureHorizon") == 0 ||
                    strcmp(keyBuf, "xdodgeFutureStride") == 0) {
             /* no-op: not supported by b0 BFS XDodge */
-        // ── RolloutDodge settings (DodgeMode::Rollout) ───────────────────────
+        // ── RolloutDodge settings (DodgeMode::RolloutGrid / RolloutQuad) ─────
         } else if (strcmp(keyBuf, "rolloutHorizonTicks") == 0) {
             RolloutDodge::SetHorizonTicks(static_cast<float>(atof(valueNorm)));
         } else if (strcmp(keyBuf, "rolloutSampleStepMs") == 0) {
@@ -1369,8 +1369,6 @@ static void DispatchCommand(char* json)
             RolloutDodge::SetIntentWeight(static_cast<float>(atof(valueNorm)));
         } else if (strcmp(keyBuf, "rolloutRebuildN") == 0) {
             RolloutDodge::SetRebuildN(atoi(valueNorm));
-        } else if (strcmp(keyBuf, "rolloutForceBrute") == 0) {
-            RolloutDodge::SetForceBruteForce(atoi(valueNorm) != 0);
         } else if (strcmp(keyBuf, "rolloutAvoidEnemies") == 0) {
             RolloutDodge::SetAvoidEnemiesEnabled(atoi(valueNorm) != 0);
         } else if (strcmp(keyBuf, "rolloutWasdYield") == 0) {

--- a/internal/src/ui/gui/tabs/TestTAB.cpp
+++ b/internal/src/ui/gui/tabs/TestTAB.cpp
@@ -125,8 +125,10 @@ void ApplyDodgeModeWithEnter(DodgeMode nextMode)
 
     // XDodge and Rollout both run from Detour_AppEngineUpdate; only one is
     // enabled at a time (mutual exclusivity enforced here).
+    const bool rollout = (nextMode == DodgeMode::RolloutGrid
+                       || nextMode == DodgeMode::RolloutQuad);
     XDodge::SetEnabled(nextMode == DodgeMode::XDodge);
-    RolloutDodge::SetEnabled(nextMode == DodgeMode::Rollout);
+    RolloutDodge::SetEnabled(rollout);
     if (nextMode == DodgeMode::XDodge) {
         XDodge::OnEnter();
         // Install the AppEngineManager::Update detour that drives the dodge Tick.
@@ -137,7 +139,10 @@ void ApplyDodgeModeWithEnter(DodgeMode nextMode)
         // (autoaim) worked. The detour is gated on XDodge/RolloutDodge
         // IsEnabled(), independent of DangerPlanner steering.
         DangerPlanner::TryInstall();
-    } else if (nextMode == DodgeMode::Rollout) {
+    } else if (rollout) {
+        // Both RE-Sim modes are the same engine; the mode selects the
+        // broad-phase backend (Grid vs Quadtree) for the A/B comparison.
+        RolloutDodge::SetBroadPhase(nextMode == DodgeMode::RolloutQuad ? 3 : 2);
         RolloutDodge::OnEnter();
         DangerPlanner::TryInstall();
     }
@@ -948,7 +953,7 @@ void TestTAB::RenderMovementSection()
     ImGui::Indent(8.f);
 
     int modeIdx = static_cast<int>(g_dodgeMode);
-    const char* modeLabels[] = { "Off", "RE-Plus", "RE-Sim" };
+    const char* modeLabels[] = { "Off", "RE-Plus", "RE-Sim (Grid)", "RE-Sim (Quadtree)" };
     ImGui::SetNextItemWidth(240.f);
     if (ImGui::Combo("Mode##dodgeModeCombo", &modeIdx, modeLabels, IM_ARRAYSIZE(modeLabels))) {
         ApplyDodgeModeWithEnter(static_cast<DodgeMode>(modeIdx));
@@ -960,7 +965,7 @@ void TestTAB::RenderMovementSection()
     if (g_dodgeMode == DodgeMode::XDodge) {
         ImGui::Spacing();
         XDodge::RenderSettings();
-    } else if (g_dodgeMode == DodgeMode::Rollout) {
+    } else if (g_dodgeMode == DodgeMode::RolloutGrid || g_dodgeMode == DodgeMode::RolloutQuad) {
         ImGui::Spacing();
         RolloutDodge::RenderSettings();
     }

--- a/internal/src/ui/gui/tabs/TestTAB.h
+++ b/internal/src/ui/gui/tabs/TestTAB.h
@@ -8,9 +8,10 @@
 namespace TestTAB {
 
 enum class DodgeMode : int {
-    Off     = 0,
-    XDodge  = 1,  // Spacetime BFS ported from XRebuild/XDriver. Movement via NativeMoveTo.
-    Rollout = 2,  // Forward input-simulation + uniform-grid broad-phase (RolloutDodge).
+    Off         = 0,
+    XDodge      = 1,  // Spacetime BFS ported from XRebuild/XDriver. Movement via NativeMoveTo.
+    RolloutGrid = 2,  // Forward input-simulation, uniform-grid broad-phase (RolloutDodge).
+    RolloutQuad = 3,  // Same engine, quadtree broad-phase (A/B against the grid version).
 };
 
 DodgeMode GetDodgeMode();


### PR DESCRIPTION
## What
Builds on the merged RolloutDodge (RE-Sim, #6). Adds a second collision
broad-phase (a self-contained quadtree) and exposes the two as separate
top-level dodge modes so they can be compared head-to-head in-game:

> Dodge mode: Off | RE-Plus | RE-Sim (Grid) | RE-Sim (Quadtree)

Same rollout engine in both RE-Sim modes — only the broad-phase that finds the
nearby bullets changes, so it's an apples-to-apples A/B.

## Details
- **`QuadtreeThreatIndex`** — self-contained region quadtree over the threats'
  swept AABBs, behind the existing `ThreatIndex` interface. Reused node pool
  (no per-frame heap churn); each threat stored once; query recurses the nodes
  overlapping the player's swept-path box. Not supahero1's lib (it drags in a
  Linux-first custom allocator that doesn't fit the MSVC DLL).
- **`DodgeMode` split** into `RolloutGrid = 2` / `RolloutQuad = 3`. The mode
  sets the broad-phase backend on enter; the brute-force scan remains the
  always-correct reference / small-N path.
- Wired through IpcBridge (`autoDodgeMode` 0..3) + `auto-dodge.ts` mode select.
  The old in-RE-Sim broad-phase debug toggle is removed (the mode is the single
  source of truth). RE-Plus (XDodge) and the grid RE-Sim are unchanged.

## Testing
Build `il2cpp-dll-injection.sln` (x64). In the Movement tab pick
**RE-Sim (Grid)** then **RE-Sim (Quadtree)** and compare. `dll-trace.log`
`[Rollout]` lines show `backend=grid` / `backend=quad`, and the debug overlay
draws each candidate rollout (green = safe → red = hit soon) + the committed
heading.
