### PR TITLE
Add configurable plugin toggle hotkeys

### DIFF
--- a/client/src/dev/public/app.js
+++ b/client/src/dev/public/app.js
@@ -2584,6 +2584,9 @@
   const pluginSearch = document.getElementById('plugin-search');
   const pluginCategory = document.getElementById('plugin-category');
   const pluginDetail = document.getElementById('plugin-detail');
+  const hotkeysSearch = document.getElementById('hotkeys-search');
+  const hotkeysTableBody = document.getElementById('hotkeys-table-body');
+  const hotkeysStatus = document.getElementById('hotkeys-status');
   let pluginsReceived = false;
   const accountsSearchInput = document.getElementById('accounts-search');
   const accountsCountEl = document.getElementById('accounts-count');
@@ -4518,8 +4521,44 @@
   // Hotkey infrastructure — maps a single key (e.g. "j") to a plugin button setting
   let hotkeyMap = new Map(); // key → { pluginId, key: buttonSettingKey }
 
+  let pluginToggleHotkeyMap = new Map(); // key -> { pluginId, enabled }
+  let capturePluginHotkeyId = null;
+
   document.addEventListener('keydown', (e) => {
+    if (capturePluginHotkeyId) {
+      e.preventDefault();
+      if (e.repeat) return;
+      if (e.key === 'Escape' && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+        capturePluginHotkeyId = null;
+        setHotkeysStatus('Capture cancelled.', '');
+        renderHotkeysTab();
+        return;
+      }
+      if (isDashboardHotkeyModifierEvent(e)) {
+        setHotkeysStatus('Now press the key to pair with ' + normalizeDashboardModifierPrefix(e) + '.', '');
+        return;
+      }
+      const hotkey = normalizeDashboardHotkeyFromEvent(e);
+      if (!hotkey) {
+        setHotkeysStatus('Unsupported hotkey.', 'error');
+        return;
+      }
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: 'updatePluginHotkey', pluginId: capturePluginHotkeyId, hotkey: hotkey }));
+        setHotkeysStatus('Saved ' + hotkey + '.', 'ok');
+      }
+      capturePluginHotkeyId = null;
+      return;
+    }
     if (['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) return;
+    if (e.repeat) return;
+    const normalized = normalizeDashboardHotkeyFromEvent(e);
+    const toggleAction = normalized ? pluginToggleHotkeyMap.get(normalized.toLowerCase()) : null;
+    if (toggleAction && ws && ws.readyState === 1) {
+      e.preventDefault();
+      ws.send(JSON.stringify({ type: 'togglePlugin', pluginId: toggleAction.pluginId, enabled: !toggleAction.enabled }));
+      return;
+    }
     const action = hotkeyMap.get(e.key.toLowerCase());
     if (action) {
       e.preventDefault();
@@ -6583,10 +6622,16 @@
           if (pl.length > 0) pluginsReceived = true;
           allPluginsData = pl;
           renderPlugins(pl);
+          if (activeTab === 'hotkeys') renderHotkeysTab();
           populateServerSelect(pl);
           renderDamageSettings(pl);
           break;
         }
+        case 'pluginHotkeyUpdateError':
+          setHotkeysStatus(msg.reason || 'Could not update hotkey.', 'error');
+          capturePluginHotkeyId = null;
+          renderHotkeysTab();
+          break;
         case 'gameClient':
           updateGameStatus(msg.connected);
           break;
@@ -9465,13 +9510,177 @@
     });
   }
 
+  function normalizeDashboardHotkeyFromEvent(e) {
+    if (!e) return '';
+    if (e.metaKey) return '';
+    var mainKey = '';
+    if (e.code && /^Numpad[0-9]$/.test(e.code)) mainKey = e.code;
+    var rawKey = String(e.key || '');
+    if (!mainKey) {
+      if (rawKey === ' ') mainKey = 'Space';
+      else {
+        var key = rawKey.trim();
+        if (!key) return '';
+        if (key.length === 1) mainKey = key.toUpperCase();
+        else {
+          var aliases = {
+            Escape: 'Escape',
+            Insert: 'Insert',
+            Delete: 'Delete',
+            Home: 'Home',
+            End: 'End',
+            PageUp: 'PageUp',
+            PageDown: 'PageDown',
+            ArrowUp: 'Up',
+            ArrowDown: 'Down',
+            ArrowLeft: 'Left',
+            ArrowRight: 'Right',
+            ' ': 'Space',
+            Spacebar: 'Space',
+            Tab: 'Tab',
+            Backspace: 'Backspace',
+            Enter: 'Enter',
+          };
+          if (/^F([1-9]|1[0-2])$/.test(key)) mainKey = key;
+          else mainKey = aliases[key] || '';
+        }
+      }
+    }
+    if (!mainKey) return '';
+    if (mainKey === 'Shift' || mainKey === 'Control' || mainKey === 'Alt' || mainKey === 'Meta') return '';
+
+    var parts = [];
+    if (e.ctrlKey) parts.push('Ctrl');
+    if (e.altKey) parts.push('Alt');
+    if (e.shiftKey) parts.push('Shift');
+    parts.push(mainKey);
+    return parts.join('+');
+  }
+
+  function isDashboardHotkeyModifierEvent(e) {
+    if (!e) return false;
+    return e.key === 'Shift' || e.key === 'Control' || e.key === 'Alt';
+  }
+
+  function normalizeDashboardModifierPrefix(e) {
+    var parts = [];
+    if (e && e.ctrlKey) parts.push('Ctrl');
+    if (e && e.altKey) parts.push('Alt');
+    if (e && e.shiftKey) parts.push('Shift');
+    return parts.join('+') || 'the modifier';
+  }
+
+  function setHotkeysStatus(text, kind) {
+    if (!hotkeysStatus) return;
+    hotkeysStatus.textContent = text || '';
+    hotkeysStatus.classList.remove('error', 'ok');
+    if (kind === 'error' || kind === 'ok') hotkeysStatus.classList.add(kind);
+  }
+
+  function renderHotkeysTab() {
+    if (!hotkeysTableBody) return;
+    var query = hotkeysSearch ? String(hotkeysSearch.value || '').trim().toLowerCase() : '';
+    var rows = (Array.isArray(allPluginsData) ? allPluginsData : [])
+      .filter(function (p) { return p && !HIDDEN_PLUGINS.has(p.id); })
+      .filter(function (p) {
+        if (!query) return true;
+        return getPluginDisplayName(p).toLowerCase().indexOf(query) >= 0
+          || String(p.id || '').toLowerCase().indexOf(query) >= 0
+          || String(p.category || '').toLowerCase().indexOf(query) >= 0;
+      })
+      .sort(function (a, b) { return getPluginDisplayName(a).localeCompare(getPluginDisplayName(b)); });
+
+    hotkeysTableBody.innerHTML = '';
+    if (!rows.length) {
+      var emptyTr = document.createElement('tr');
+      var emptyTd = document.createElement('td');
+      emptyTd.colSpan = 5;
+      emptyTd.className = 'hotkeys-empty';
+      emptyTd.textContent = pluginsReceived ? 'No plugins match the current search.' : 'Loading plugins...';
+      emptyTr.appendChild(emptyTd);
+      hotkeysTableBody.appendChild(emptyTr);
+      return;
+    }
+
+    rows.forEach(function (p) {
+      var tr = document.createElement('tr');
+      if (capturePluginHotkeyId === p.id) tr.className = 'hotkeys-capture-row';
+
+      var nameTd = document.createElement('td');
+      var name = document.createElement('div');
+      name.className = 'hotkeys-plugin-name';
+      name.textContent = getPluginDisplayName(p);
+      var id = document.createElement('div');
+      id.className = 'hotkeys-muted';
+      id.textContent = p.id;
+      nameTd.appendChild(name);
+      nameTd.appendChild(id);
+
+      var catTd = document.createElement('td');
+      catTd.textContent = t(PLUGIN_CATEGORY_LABEL_KEYS[p.category || 'utility']) || (p.category || 'utility');
+
+      var statusTd = document.createElement('td');
+      statusTd.textContent = p.hotkeyLocked ? 'Always on' : (p.enabled ? 'Enabled' : 'Disabled');
+
+      var keyTd = document.createElement('td');
+      var key = document.createElement('span');
+      key.className = 'hotkeys-key';
+      key.textContent = capturePluginHotkeyId === p.id ? 'Press key combo' : (p.hotkey || 'None');
+      keyTd.appendChild(key);
+
+      var actionsTd = document.createElement('td');
+      var actions = document.createElement('div');
+      actions.className = 'hotkeys-actions';
+      var setBtn = document.createElement('button');
+      setBtn.type = 'button';
+      setBtn.className = 'setting-btn';
+      setBtn.textContent = capturePluginHotkeyId === p.id ? 'Listening' : 'Set';
+      setBtn.disabled = !!p.hotkeyLocked;
+      setBtn.addEventListener('click', function () {
+        capturePluginHotkeyId = p.id;
+        setHotkeysStatus('Press a key combo for ' + getPluginDisplayName(p) + '. Escape cancels.', '');
+        renderHotkeysTab();
+      });
+      var clearBtn = document.createElement('button');
+      clearBtn.type = 'button';
+      clearBtn.className = 'setting-btn setting-btn-secondary';
+      clearBtn.textContent = 'Clear';
+      clearBtn.disabled = !!p.hotkeyLocked || !p.hotkey;
+      clearBtn.addEventListener('click', function () {
+        if (!ws || ws.readyState !== 1) return;
+        ws.send(JSON.stringify({ type: 'updatePluginHotkey', pluginId: p.id, hotkey: '' }));
+        setHotkeysStatus('Cleared hotkey for ' + getPluginDisplayName(p) + '.', 'ok');
+      });
+      actions.appendChild(setBtn);
+      actions.appendChild(clearBtn);
+      actionsTd.appendChild(actions);
+
+      tr.appendChild(nameTd);
+      tr.appendChild(catTd);
+      tr.appendChild(statusTd);
+      tr.appendChild(keyTd);
+      tr.appendChild(actionsTd);
+      hotkeysTableBody.appendChild(tr);
+    });
+  }
+
+  if (hotkeysSearch) {
+    hotkeysSearch.addEventListener('input', function () {
+      renderHotkeysTab();
+    });
+  }
+
   function renderPlugins(plugins) {
     cachedPluginsForHub = Array.isArray(plugins) ? plugins : [];
     initPluginHubFiltersOnce();
     populatePluginCategorySelect();
 
     hotkeyMap.clear();
+    pluginToggleHotkeyMap.clear();
     cachedPluginsForHub.forEach(function (p) {
+      if (p.hotkey && !p.hotkeyLocked) {
+        pluginToggleHotkeyMap.set(String(p.hotkey).toLowerCase(), { pluginId: p.id, enabled: !!p.enabled });
+      }
       (p.settings || []).forEach(function (s) {
         if (s.hotkeyFor && s.value) {
           hotkeyMap.set(String(s.value).toLowerCase(), { pluginId: p.id, key: s.hotkeyFor });
@@ -11672,6 +11881,22 @@
           renderPlugins(pl);
           populateServerSelect(pl);
           renderDamageSettings(pl);
+        })
+        .catch(function () {});
+    }
+    if (tabName === 'hotkeys') {
+      renderHotkeysTab();
+      fetch('/api/plugins')
+        .then(function (r) {
+          if (!r.ok) throw new Error('bad status');
+          return r.json();
+        })
+        .then(function (data) {
+          var pl = Array.isArray(data) ? data : [];
+          if (pl.length > 0) pluginsReceived = true;
+          allPluginsData = pl;
+          renderPlugins(pl);
+          renderHotkeysTab();
         })
         .catch(function () {});
     }

--- a/client/src/dev/public/index.html
+++ b/client/src/dev/public/index.html
@@ -238,6 +238,7 @@
       <div id="content-tabs">
         <button class="content-tab active" data-tab="home" data-icon="H" data-label="Home" data-i18n="tab.home">Home</button>
         <button class="content-tab" data-tab="plugins" data-icon="P" data-label="Plugins" data-i18n="tab.plugins">Plugins</button>
+        <button class="content-tab" data-tab="hotkeys" data-icon="K" data-label="Hotkeys">Hotkeys</button>
         <button class="content-tab admin-only" data-tab="market" data-icon="$" data-label="Market" data-i18n="tab.market">Market</button>
         <button class="content-tab" data-tab="accounts" data-icon="A" data-label="Accounts" data-i18n="tab.accounts">Accounts</button>
         <button class="content-tab admin-only" data-tab="logs" data-icon="L" data-label="Logs" data-i18n="tab.logs">Logs</button>
@@ -439,6 +440,33 @@
               </div>
             </div>
           </main>
+        </div>
+      </div>
+
+      <div id="tab-hotkeys" class="tab-panel" style="display:none;">
+        <div class="hotkeys-page">
+          <div class="hotkeys-toolbar">
+            <div>
+              <h2 class="hotkeys-title">Plugin Hotkeys</h2>
+              <p class="hotkeys-subtitle">Bind a key to toggle each plugin while the game window is focused.</p>
+            </div>
+            <input type="search" id="hotkeys-search" class="hotkeys-search" placeholder="Search plugins..." autocomplete="off" spellcheck="false" aria-label="Search plugin hotkeys">
+          </div>
+          <div id="hotkeys-status" class="hotkeys-status" aria-live="polite"></div>
+          <div class="hotkeys-table-wrap">
+            <table class="hotkeys-table">
+              <thead>
+                <tr>
+                  <th>Plugin</th>
+                  <th>Category</th>
+                  <th>Status</th>
+                  <th>Hotkey</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody id="hotkeys-table-body"></tbody>
+            </table>
+          </div>
         </div>
       </div>
 

--- a/client/src/dev/public/style.css
+++ b/client/src/dev/public/style.css
@@ -7288,6 +7288,139 @@ body.theme-mist .rotmg-item-sprite {
   100% { background-position: -200% 0; }
 }
 
+/* Plugin hotkeys */
+.hotkeys-page {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+  padding: 14px;
+}
+
+.hotkeys-toolbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.hotkeys-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0;
+}
+
+.hotkeys-subtitle {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.hotkeys-search {
+  width: min(280px, 42vw);
+  background: var(--bg-card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+}
+
+.hotkeys-search:focus {
+  outline: none;
+  border-color: var(--border-hover);
+}
+
+.hotkeys-status {
+  min-height: 18px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.hotkeys-status.error { color: var(--danger); }
+.hotkeys-status.ok { color: var(--success); }
+
+.hotkeys-table-wrap {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+}
+
+.hotkeys-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.hotkeys-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  text-align: left;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.hotkeys-table td {
+  padding: 9px 12px;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+  vertical-align: middle;
+}
+
+body.light-mode .hotkeys-table td,
+body.theme-light .hotkeys-table td {
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+}
+
+.hotkeys-plugin-name {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.hotkeys-muted {
+  color: var(--text-muted);
+}
+
+.hotkeys-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 58px;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--plugin-settings-bg);
+  color: var(--text);
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+  font-size: 12px;
+}
+
+.hotkeys-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hotkeys-capture-row td {
+  background: rgba(47, 129, 247, 0.08);
+}
+
+.hotkeys-empty {
+  padding: 34px 16px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
 .empty-state {
   text-align: center;
   color: var(--text-muted);

--- a/client/src/dev/server/DevServer.ts
+++ b/client/src/dev/server/DevServer.ts
@@ -1086,7 +1086,7 @@ export class DevServer {
     name: string;
     createdAt: number;
     updatedAt: number;
-    plugins: Array<{ id: string; enabled: boolean; settings: Record<string, unknown> }>;
+    plugins: Array<{ id: string; enabled: boolean; hotkey: string; settings: Record<string, unknown> }>;
   } {
     const now = Date.now();
     const plugins = this.pluginManager.getPlugins().map((p) => {
@@ -1096,7 +1096,7 @@ export class DevServer {
         if (s.type === 'button') continue;
         settings[s.key] = s.value;
       }
-      return { id: p.id, enabled: !!p.enabled, settings };
+      return { id: p.id, enabled: !!p.enabled, hotkey: String((p as any).hotkey || ''), settings };
     });
     return {
       id: this.sanitizeConfigId(name),
@@ -1162,6 +1162,12 @@ export class DevServer {
       if (typeof p.enabled === 'boolean') {
         this.pluginManager.togglePlugin(p.id, p.enabled);
       }
+      if (typeof p.hotkey === 'string') {
+        const result = this.pluginManager.updatePluginHotkey(p.id, p.hotkey);
+        if (!result.ok) {
+          Logger.warn('DevServer', `Skipped hotkey for ${p.id}: ${result.reason || 'invalid hotkey'}`);
+        }
+      }
       if (p.settings && typeof p.settings === 'object') {
         for (const [key, value] of Object.entries(p.settings as Record<string, unknown>)) {
           // Never execute button settings from a config replay.
@@ -1172,6 +1178,7 @@ export class DevServer {
       }
     }
     this.broadcastPluginState();
+    this.syncPluginHotkeysToDll();
     return { ok: true, message: `Loaded config "${String(snapshot.name || snapshot.id || 'config')}".` };
   }
 
@@ -1376,7 +1383,10 @@ export class DevServer {
   /** Stash the named-pipe bridge so other dashboard subsystems can talk to the injected DLL. */
   setInternalBridge(bridge: InternalBridge): void {
     this.internalBridge = bridge;
-    bridge.on('authenticated', () => this.broadcastInternalState());
+    bridge.on('authenticated', () => {
+      this.broadcastInternalState();
+      this.syncPluginHotkeysToDll();
+    });
     bridge.on('disconnected',  () => this.broadcastInternalState());
     bridge.on('unresolvedClasses', (list: string[]) => {
       this.lastUnresolvedClasses = list;
@@ -4625,6 +4635,19 @@ export class DevServer {
           }
           this.broadcastPluginState();
           this.scheduleAutosave();
+        } else if (msg.type === 'updatePluginHotkey') {
+          const result = this.pluginManager.updatePluginHotkey(msg.pluginId, msg.hotkey);
+          if (!result.ok && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({
+              type: 'pluginHotkeyUpdateError',
+              pluginId: msg.pluginId,
+              reason: result.reason,
+              conflictPluginId: result.conflictPluginId ?? null,
+            }));
+          }
+          this.broadcastPluginState();
+          this.syncPluginHotkeysToDll();
+          this.scheduleAutosave();
         } else if (msg.type === 'resetPluginSettings') {
           const changed = this.pluginManager.resetPluginSettings(String(msg.pluginId ?? ''));
           if (ws.readyState === WebSocket.OPEN) {
@@ -5174,10 +5197,23 @@ export class DevServer {
     }
   }
 
+  private syncPluginHotkeysToDll(): void {
+    try {
+      const bindings = this.pluginManager.getPluginHotkeyBindings();
+      const payload = bindings
+        .map((b) => `${b.pluginId}=${b.hotkey}`)
+        .join(';');
+      this.internalBridge?.setFeature('pluginToggleHotkeys', payload);
+    } catch (err) {
+      Logger.warn('DevServer', `plugin hotkey sync failed: ${(err as Error).message}`);
+    }
+  }
+
   broadcastDllMessage(msg: any): void {
     if (msg?.type === 'hotkeyEvent') {
       if (this.applyInternalHotkeyEvent(msg)) {
         this.broadcastPluginState();
+        this.syncPluginHotkeysToDll();
         this.scheduleAutosave();
       }
     }
@@ -5193,6 +5229,17 @@ export class DevServer {
     }
     if (pluginId === 'player-noclip' && action === 'noclipEnabled') {
       return this.pluginManager.updateSetting('player-noclip', 'noclipEnabled', value);
+    }
+    if (action === 'togglePlugin') {
+      const result = this.pluginManager.togglePluginByHotkey(pluginId);
+      if (result.ok) {
+        this.eventTracker?.track('plugin_toggle', {
+          plugin: pluginId,
+          enabled: !!result.enabled,
+          source: 'hotkey',
+        });
+      }
+      return result.ok;
     }
     if (pluginId === 'ghostHit') {
       this.handleGhostHitEvent(action);

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -121,6 +121,16 @@ function resolveInternalVersionDllPath(pathOrDir: string): string | null {
   return null;
 }
 
+function resolveDefaultDevInternalDll(): string | null {
+  const candidates = [
+    resolve(APP_ROOT, '..', 'internal', 'x64', 'Debug', 'version.dll'),
+    resolve(APP_ROOT, '..', 'internal', 'x64', 'Release', 'version.dll'),
+    resolve(APP_ROOT, '..', 'DebugInternal', 'x64', 'Debug', 'version.dll'),
+    resolve(APP_ROOT, '..', 'DebugInternal', 'x64', 'Release', 'version.dll'),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
 function loadClientDataConfig(): ClientDataConfig {
   const empty: ClientDataConfig = {
     rotmgPath: null,
@@ -192,7 +202,7 @@ async function main() {
     | 'skipped_env'
     | 'none'
     | 'error' = 'none';
-  /** Set when both internal.bin and DebugInternal\\x64\\Release\\version.dll exist; logged for deploy diagnostics. */
+  /** Set when both internal.bin and a local dev version.dll exist; logged for deploy diagnostics. */
   let internalBinMtimeMs: number | null = null;
   let devDllMtimeMs: number | null = null;
   if (hooker.gameDirectory) {
@@ -210,7 +220,7 @@ async function main() {
       const binPath = resolve(assetsDir, 'internal.bin');
       // APP_ROOT = bot-client dir (Electron sets REALM_ENGINE_APP_ROOT). ROOT may be resourcesPath in prod,
       // so never use ROOT/.. for repo siblings — that misses LFG/DebugInternal next to LFG/bot-client.
-      const devDll = resolve(APP_ROOT, '..', 'DebugInternal', 'x64', 'Release', 'version.dll');
+      const devDll = resolveDefaultDevInternalDll();
 
       const envDllResolved = resolveInternalVersionDllPath(
         String(process.env.REALM_ENGINE_INTERNAL_VERSION_DLL || ''),
@@ -241,7 +251,7 @@ async function main() {
 
       // If a local DebugInternal build is newer than the shipped encrypted blob, prefer it.
       // Stale internal.bin often mismatches the live Exalt client and crashes inside IL2CPP/hooks.
-      if (existsSync(binPath) && existsSync(devDll)) {
+      if (devDll && existsSync(binPath)) {
         try {
           internalBinMtimeMs = statSync(binPath).mtimeMs;
           devDllMtimeMs = statSync(devDll).mtimeMs;
@@ -264,7 +274,7 @@ async function main() {
         } catch {}
       }
       // Dev fallback: copy raw DLL from DebugInternal build output
-      if (!deployed && existsSync(devDll)) {
+      if (!deployed && devDll) {
         try {
           copyFileSync(devDll, cheatDllDest);
           deployed = true;
@@ -274,7 +284,7 @@ async function main() {
       if (deployed) {
         Logger.log('Main', `Internal DLL deployed to ${cheatDllDest}`);
       } else {
-        Logger.warn('Main', 'Internal DLL not found (no assets/internal.bin and no DebugInternal build). DLL features unavailable.');
+        Logger.warn('Main', 'Internal DLL not found (no assets/internal.bin and no local internal build). DLL features unavailable.');
       }
     } catch (err) {
       versionDeploySource = 'error';
@@ -303,7 +313,7 @@ async function main() {
       } catch {
         wSz = null;
       }
-      const logDevDll = resolve(APP_ROOT, '..', 'DebugInternal', 'x64', 'Release', 'version.dll');
+      const logDevDll = resolveDefaultDevInternalDll();
       const logBinPath = resolve(assetsDir, 'internal.bin');
       let binMtimeProbe: number | null = null;
       let devMtimeProbe: number | null = null;
@@ -313,7 +323,7 @@ async function main() {
         binMtimeProbe = null;
       }
       try {
-        if (existsSync(logDevDll)) devMtimeProbe = statSync(logDevDll).mtimeMs;
+        if (logDevDll && existsSync(logDevDll)) devMtimeProbe = statSync(logDevDll).mtimeMs;
       } catch {
         devMtimeProbe = null;
       }

--- a/client/src/plugins/PluginManager.ts
+++ b/client/src/plugins/PluginManager.ts
@@ -58,6 +58,7 @@ interface LoadedPlugin {
   name: string;
   filePath: string;
   source: PluginSource;
+  hotkey: string;
   context: AnyPluginContext;
   /**
    * Optional teardown returned from a user plugin's `register(ctx)` call.
@@ -72,6 +73,84 @@ const USER_PLUGIN_EXTS = ['.mjs'] as const;
 
 function stripPluginExt(fileName: string): string {
   return fileName.replace(/\.(?:mjs|js|ts)$/i, '');
+}
+
+const HOTKEY_ALIASES = new Map<string, string>([
+  ['ESC', 'Escape'],
+  ['ESCAPE', 'Escape'],
+  ['INS', 'Insert'],
+  ['INSERT', 'Insert'],
+  ['DEL', 'Delete'],
+  ['DELETE', 'Delete'],
+  ['HOME', 'Home'],
+  ['END', 'End'],
+  ['PGUP', 'PageUp'],
+  ['PAGEUP', 'PageUp'],
+  ['PGDN', 'PageDown'],
+  ['PAGEDOWN', 'PageDown'],
+  ['UP', 'Up'],
+  ['ARROWUP', 'Up'],
+  ['DOWN', 'Down'],
+  ['ARROWDOWN', 'Down'],
+  ['LEFT', 'Left'],
+  ['ARROWLEFT', 'Left'],
+  ['RIGHT', 'Right'],
+  ['ARROWRIGHT', 'Right'],
+  ['SPACE', 'Space'],
+  ['SPACEBAR', 'Space'],
+  ['TAB', 'Tab'],
+  ['BACKSPACE', 'Backspace'],
+  ['ENTER', 'Enter'],
+  ['RETURN', 'Enter'],
+]);
+
+const HOTKEY_MODIFIER_ALIASES = new Map<string, string>([
+  ['CTRL', 'Ctrl'],
+  ['CONTROL', 'Ctrl'],
+  ['ALT', 'Alt'],
+  ['MENU', 'Alt'],
+  ['SHIFT', 'Shift'],
+]);
+
+function normalizeHotkeyKey(raw: string): string | null {
+  const compact = raw.replace(/\s+/g, '').toUpperCase();
+  if (!compact) return null;
+  if (/^[A-Z0-9]$/.test(compact)) return compact;
+  const fKey = compact.match(/^F([1-9]|1[0-2])$/);
+  if (fKey) return `F${fKey[1]}`;
+  const numpad = compact.match(/^(?:NUMPAD|NUM)([0-9])$/);
+  if (numpad) return `Numpad${numpad[1]}`;
+  const alias = HOTKEY_ALIASES.get(compact);
+  if (alias) return alias;
+  return null;
+}
+
+function normalizeHotkey(raw: unknown): string | null {
+  const input = String(raw ?? '').trim();
+  if (!input) return '';
+  const parts = input.split('+').map((part) => part.trim()).filter(Boolean);
+  if (!parts.length) return '';
+
+  const modifiers = new Set<string>();
+  let mainKey = '';
+
+  for (const part of parts) {
+    const compact = part.replace(/\s+/g, '').toUpperCase();
+    const modifier = HOTKEY_MODIFIER_ALIASES.get(compact);
+    if (modifier) {
+      modifiers.add(modifier);
+      continue;
+    }
+    if (mainKey) return null;
+    const normalized = normalizeHotkeyKey(part);
+    if (!normalized) return null;
+    mainKey = normalized;
+  }
+
+  if (!mainKey) return null;
+
+  const orderedModifiers = ['Ctrl', 'Alt', 'Shift'].filter((modifier) => modifiers.has(modifier));
+  return [...orderedModifiers, mainKey].join('+');
 }
 
 interface SecurePluginRecord {
@@ -173,7 +252,7 @@ export class PluginManager {
   }
 
   /** Get all loaded plugins (for dashboard). Admin-gated plugins hidden when adminMode is off. */
-  getPlugins(): { id: string; name: string; enabled: boolean; category: PluginCategory; settings: any[]; source: PluginSource; requiredPlan: string | null }[] {
+  getPlugins(): { id: string; name: string; enabled: boolean; category: PluginCategory; settings: any[]; source: PluginSource; requiredPlan: string | null; hotkey: string; hotkeyLocked: boolean }[] {
     return Array.from(this.loadedPlugins.values())
       .filter(p => !this.isAdminGated(p.id) || this.adminMode)
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -185,6 +264,8 @@ export class PluginManager {
         settings: this.getDashboardSettings(p),
         source: p.source,
         requiredPlan: this.getRequiredPlan(p.id),
+        hotkey: p.hotkey,
+        hotkeyLocked: this.isAlwaysEnabled(p.id),
       }));
   }
 
@@ -267,6 +348,49 @@ export class PluginManager {
     // Admin dev: all gate checks removed — every plugin can be toggled freely.
     plugin.context.enabled = enabled;
     return { ok: true };
+  }
+
+  togglePluginByHotkey(pluginId: string): { ok: boolean; enabled?: boolean; reason?: string; requiredPlan?: string } {
+    const plugin = this.loadedPlugins.get(pluginId);
+    if (!plugin) return { ok: false, reason: 'Plugin not found' };
+    if (!plugin.hotkey) return { ok: false, reason: 'Plugin has no hotkey' };
+    if (this.isAlwaysEnabled(pluginId)) return { ok: false, reason: 'Plugin is always enabled' };
+    const nextEnabled = !plugin.context.enabled;
+    const result = this.togglePlugin(pluginId, nextEnabled);
+    return result.ok ? { ...result, enabled: nextEnabled } : result;
+  }
+
+  updatePluginHotkey(pluginId: string, rawHotkey: unknown): { ok: boolean; hotkey?: string; reason?: string; conflictPluginId?: string } {
+    const plugin = this.loadedPlugins.get(pluginId);
+    if (!plugin) return { ok: false, reason: 'Plugin not found' };
+    if (this.isAlwaysEnabled(pluginId)) return { ok: false, reason: 'Plugin is always enabled' };
+
+    const hotkey = normalizeHotkey(rawHotkey);
+    if (hotkey === null) return { ok: false, reason: 'Unsupported hotkey' };
+
+    if (hotkey) {
+      const hotkeyLower = hotkey.toLowerCase();
+      for (const other of this.loadedPlugins.values()) {
+        if (other.id === pluginId) continue;
+        if (other.hotkey && other.hotkey.toLowerCase() === hotkeyLower) {
+          return {
+            ok: false,
+            reason: `Hotkey already assigned to ${other.name || other.id}`,
+            conflictPluginId: other.id,
+          };
+        }
+      }
+    }
+
+    plugin.hotkey = hotkey;
+    Logger.log('PluginManager', `Hotkey for ${plugin.name || plugin.id}: ${hotkey || '(none)'}`);
+    return { ok: true, hotkey };
+  }
+
+  getPluginHotkeyBindings(): Array<{ pluginId: string; hotkey: string }> {
+    return Array.from(this.loadedPlugins.values())
+      .filter((p) => !!p.hotkey && !this.isAlwaysEnabled(p.id))
+      .map((p) => ({ pluginId: p.id, hotkey: p.hotkey }));
   }
 
   /**
@@ -476,6 +600,7 @@ export class PluginManager {
         name: context.name || id,
         filePath,
         source,
+        hotkey: '',
         context,
         userCleanup,
       });
@@ -634,6 +759,7 @@ export class PluginManager {
         name: context.name || id,
         filePath: `remote:${id}`,
         source: 'bundled',
+        hotkey: '',
         context,
         userCleanup: null,
       });

--- a/internal/src/ui/IpcBridge.cpp
+++ b/internal/src/ui/IpcBridge.cpp
@@ -168,6 +168,15 @@ static std::atomic<int>   s_featPlayerNoclipHotkeyVk{'N'};
 static std::atomic<int>   s_pendingPlayerNoclipEnabled{-1};
 static std::atomic<int>   s_featSocketHotkeyActive{0};
 static std::atomic<int>   s_featSocketHotkeyVk{'L'};
+struct PluginToggleHotkeyBinding {
+    char pluginId[96];
+    int mainVk;
+    bool requireShift;
+    bool requireCtrl;
+    bool requireAlt;
+    bool lastDown;
+};
+static std::vector<PluginToggleHotkeyBinding> s_pluginToggleHotkeys;
 static std::atomic<int>   s_featWalkTargetActive{0};
 static std::atomic<float> s_featWalkTargetX{0.f};
 static std::atomic<float> s_featWalkTargetY{0.f};
@@ -341,6 +350,53 @@ int ResolveHotkeyVk(const char* raw)
     return 0;
 }
 
+bool ParsePluginToggleHotkey(const char* raw, PluginToggleHotkeyBinding& binding)
+{
+    if (!raw) return false;
+
+    std::string input(raw);
+    size_t start = 0;
+    int mainVk = 0;
+    bool requireShift = false;
+    bool requireCtrl = false;
+    bool requireAlt = false;
+
+    while (start <= input.size()) {
+        const size_t end = input.find('+', start);
+        std::string part = input.substr(start, end == std::string::npos ? std::string::npos : end - start);
+        std::string compact;
+        for (const char ch : part) {
+            const unsigned char c = static_cast<unsigned char>(ch);
+            if (!std::isspace(c))
+                compact.push_back(static_cast<char>(std::toupper(c)));
+        }
+
+        if (!compact.empty()) {
+            if (compact == "SHIFT") {
+                requireShift = true;
+            } else if (compact == "CTRL" || compact == "CONTROL") {
+                requireCtrl = true;
+            } else if (compact == "ALT" || compact == "MENU") {
+                requireAlt = true;
+            } else {
+                if (mainVk != 0) return false;
+                mainVk = ResolveHotkeyVk(compact.c_str());
+                if (mainVk == VK_SHIFT || mainVk == VK_CONTROL || mainVk == VK_MENU) return false;
+            }
+        }
+
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+
+    if (mainVk == 0) return false;
+    binding.mainVk = mainVk;
+    binding.requireShift = requireShift;
+    binding.requireCtrl = requireCtrl;
+    binding.requireAlt = requireAlt;
+    return true;
+}
+
 bool IsCurrentProcessForeground()
 {
     HWND hwnd = GetForegroundWindow();
@@ -387,6 +443,93 @@ bool PollSocketHotkeyEvent()
     const bool shouldFire = hotkeyDown && !s_lastHotkeyDown;
     s_lastHotkeyDown = hotkeyDown;
     return shouldFire;
+}
+
+bool IsVkDown(int vk)
+{
+    return ((GetAsyncKeyState(vk) | GetKeyState(vk)) & 0x8000) != 0;
+}
+
+bool IsShiftDown()
+{
+    return IsVkDown(VK_SHIFT) || IsVkDown(VK_LSHIFT) || IsVkDown(VK_RSHIFT);
+}
+
+bool IsCtrlDown()
+{
+    return IsVkDown(VK_CONTROL) || IsVkDown(VK_LCONTROL) || IsVkDown(VK_RCONTROL);
+}
+
+bool IsAltDown()
+{
+    return IsVkDown(VK_MENU) || IsVkDown(VK_LMENU) || IsVkDown(VK_RMENU);
+}
+
+bool IsPluginToggleHotkeyDown(const PluginToggleHotkeyBinding& binding, bool foreground)
+{
+    if (!foreground || binding.mainVk == 0) return false;
+    if (binding.requireShift && !IsShiftDown()) return false;
+    if (binding.requireCtrl && !IsCtrlDown()) return false;
+    if (binding.requireAlt && !IsAltDown()) return false;
+    return IsVkDown(binding.mainVk);
+}
+
+bool IsPluginHotkeyIdSafe(const char* s)
+{
+    if (!s || !*s) return false;
+    size_t len = strlen(s);
+    if (len >= 96) return false;
+    for (size_t i = 0; i < len; ++i) {
+        const char c = s[i];
+        const bool ok =
+            (c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') ||
+            c == '-' || c == '_' || c == '.';
+        if (!ok) return false;
+    }
+    return true;
+}
+
+void ApplyPluginToggleHotkeys(const char* spec)
+{
+    s_pluginToggleHotkeys.clear();
+    if (!spec || !*spec) return;
+
+    std::string input(spec);
+    size_t start = 0;
+    while (start < input.size()) {
+        const size_t end = input.find(';', start);
+        const std::string token = input.substr(start, end == std::string::npos ? std::string::npos : end - start);
+        const size_t eq = token.find('=');
+        if (eq != std::string::npos) {
+            const std::string pluginId = token.substr(0, eq);
+            const std::string hotkey = token.substr(eq + 1);
+            if (IsPluginHotkeyIdSafe(pluginId.c_str())) {
+                PluginToggleHotkeyBinding binding{};
+                if (ParsePluginToggleHotkey(hotkey.c_str(), binding)) {
+                    strncpy_s(binding.pluginId, sizeof(binding.pluginId), pluginId.c_str(), _TRUNCATE);
+                    binding.lastDown = IsPluginToggleHotkeyDown(binding, IsCurrentProcessForeground());
+                    s_pluginToggleHotkeys.push_back(binding);
+                }
+            }
+        }
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+}
+
+void CollectPluginToggleHotkeyEvents(std::vector<std::string>& outPluginIds)
+{
+    if (s_pluginToggleHotkeys.empty()) return;
+    const bool foreground = IsCurrentProcessForeground();
+    for (auto& binding : s_pluginToggleHotkeys) {
+        const bool down = IsPluginToggleHotkeyDown(binding, foreground);
+        if (down && !binding.lastDown) {
+            outPluginIds.emplace_back(binding.pluginId);
+        }
+        binding.lastDown = down;
+    }
 }
 
 void ApplyWalkTargetFeatureState()
@@ -1224,7 +1367,7 @@ static void DispatchCommand(char* json)
     {
         char keyBuf[64] = {};
         char valueType[8] = {};
-        char valueNorm[128] = {};
+        char valueNorm[4096] = {};
         if (!JsonGetString(json, "key", keyBuf, sizeof(keyBuf))) return;
         if (!JsonGetString(json, "valueType", valueType, sizeof(valueType))) return;
 
@@ -1239,7 +1382,7 @@ static void DispatchCommand(char* json)
             return;
         }
 
-        char payload[256] = {};
+        char payload[8192] = {};
         snprintf(payload, sizeof(payload), "%s|%s|%s", keyBuf, valueType, valueNorm);
         if (!VerifyClientSeqAndMac(seqStr, macHex, "setFeature", payload)) {
             DBG_FILE_LOG("[IpcBridge] setFeature HMAC REJECTED: key=" << keyBuf << " valueType=" << valueType << " value=" << valueNorm);
@@ -1398,6 +1541,8 @@ static void DispatchCommand(char* json)
             s_featSocketHotkeyActive.store(JsonGetBool(json, "value") ? 1 : 0, std::memory_order_relaxed);
         } else if (strcmp(keyBuf, "socketHotkey") == 0) {
             s_featSocketHotkeyVk.store(ResolveHotkeyVk(valueNorm), std::memory_order_relaxed);
+        } else if (strcmp(keyBuf, "pluginToggleHotkeys") == 0) {
+            ApplyPluginToggleHotkeys(valueNorm);
         } else if (strcmp(keyBuf, "walkTargetX") == 0) {
             s_featWalkTargetX.store(static_cast<float>(atof(valueNorm)), std::memory_order_relaxed);
         } else if (strcmp(keyBuf, "walkTargetY") == 0) {
@@ -1638,6 +1783,24 @@ DWORD WINAPI IpcBridgeThread(LPVOID)
                         break;
                     }
                 }
+
+                std::vector<std::string> pluginToggleEvents;
+                CollectPluginToggleHotkeyEvents(pluginToggleEvents);
+                for (const auto& pluginId : pluginToggleEvents)
+                {
+                    if (!WriteSignedHotkeyEvent(
+                        hPipe,
+                        msgBuf,
+                        sizeof(msgBuf),
+                        pluginId.c_str(),
+                        "togglePlugin",
+                        true))
+                    {
+                        connected = false;
+                        break;
+                    }
+                }
+                if (!connected) break;
 
                 const int noclipEnabled = s_pendingPlayerNoclipEnabled.exchange(-1, std::memory_order_relaxed);
                 if (noclipEnabled >= 0)


### PR DESCRIPTION
## Summary
- Add user-configurable plugin toggle hotkeys with a dedicated dashboard Hotkeys tab
- Sync plugin toggle bindings to the internal DLL for in-game hotkey toggles
- Support modifier combos such as Ctrl+A and Shift+W with edge-triggered handling
- Prefer the local Debug internal DLL for dev testing

## Testing
- node --check src/dev/public/app.js
- MSBuild internal/il2cpp-dll-injection.sln /p:Configuration=Debug /p:Platform=x64
- Verified Ctrl+A hotkey save/clear over the live dashboard websocket
- Reloaded RotMG and observed plugin toggles from in-game hotkey events