### PR TITLE
Added projectile path/store/runtime-reader system

### DIFF
--- a/internal/il2cpp-dll-injection.vcxproj
+++ b/internal/il2cpp-dll-injection.vcxproj
@@ -69,6 +69,9 @@
     <ClCompile Include="src\platform\hooks\DirectX.cpp" />
     <ClCompile Include="src\platform\hooks\InitHooks.cpp" />
     <ClCompile Include="src\features\movement\dodge\ProjectileTracking.cpp" />
+    <ClCompile Include="src\features\projectiles\ProjectileRuntimeReader.cpp" />
+    <ClCompile Include="src\features\projectiles\ProjectileStore.cpp" />
+    <ClCompile Include="src\features\projectiles\ProjectileTrajectory.cpp" />
     <ClCompile Include="src\features\account\HwidCapture.cpp" />
     <ClCompile Include="src\features\account\CharSelect.cpp" />
     <ClCompile Include="src\features\account\CredentialCapture.cpp" />
@@ -168,6 +171,9 @@
     <ClInclude Include="src\platform\hooks\DirectX.h" />
     <ClInclude Include="src\platform\hooks\InitHooks.h" />
     <ClInclude Include="src\features\movement\dodge\ProjectileTracking.h" />
+    <ClInclude Include="src\features\projectiles\ProjectileRuntimeReader.h" />
+    <ClInclude Include="src\features\projectiles\ProjectileStore.h" />
+    <ClInclude Include="src\features\projectiles\ProjectileTrajectory.h" />
     <ClInclude Include="src\features\account\HwidCapture.h" />
     <ClInclude Include="src\features\account\CharSelect.h" />
     <ClInclude Include="src\features\account\CredentialCapture.h" />

--- a/internal/il2cpp-dll-injection.vcxproj.filters
+++ b/internal/il2cpp-dll-injection.vcxproj.filters
@@ -35,6 +35,9 @@
     <ClCompile Include="src\platform\hooks\DirectX.cpp" />
     <ClCompile Include="src\platform\hooks\InitHooks.cpp" />
     <ClCompile Include="src\features\movement\dodge\ProjectileTracking.cpp" />
+    <ClCompile Include="src\features\projectiles\ProjectileRuntimeReader.cpp" />
+    <ClCompile Include="src\features\projectiles\ProjectileStore.cpp" />
+    <ClCompile Include="src\features\projectiles\ProjectileTrajectory.cpp" />
     <ClCompile Include="src\features\account\HwidCapture.cpp" />
     <ClCompile Include="src\features\account\CharSelect.cpp" />
     <ClCompile Include="src\features\account\CredentialCapture.cpp" />
@@ -95,6 +98,9 @@
     <ClInclude Include="src\platform\hooks\DirectX.h" />
     <ClInclude Include="src\platform\hooks\InitHooks.h" />
     <ClInclude Include="src\features\movement\dodge\ProjectileTracking.h" />
+    <ClInclude Include="src\features\projectiles\ProjectileRuntimeReader.h" />
+    <ClInclude Include="src\features\projectiles\ProjectileStore.h" />
+    <ClInclude Include="src\features\projectiles\ProjectileTrajectory.h" />
     <ClInclude Include="src\features\account\HwidCapture.h" />
     <ClInclude Include="src\features\account\CharSelect.h" />
     <ClInclude Include="src\features\account\CredentialCapture.h" />

--- a/internal/src/features/movement/dodge/ProjectileTracking.cpp
+++ b/internal/src/features/movement/dodge/ProjectileTracking.cpp
@@ -2,6 +2,9 @@
 
 #include "ProjectileTracking.h"
 #include "ProjectileCatalog.h"
+#include "../../projectiles/ProjectileRuntimeReader.h"
+#include "../../projectiles/ProjectileStore.h"
+#include "../../projectiles/ProjectileTrajectory.h"
 #include "AutoAim.h"
 #include "FeatMagnetAim.h"
 #include "gui/tabs/WorldTAB.h"
@@ -13,10 +16,8 @@
 
 #include <windows.h>
 #include "minhook/MinHook.h"
-
 #include <atomic>
 #include <cmath>
-#include <cstdio>
 #include <cstring>
 #include <unordered_map>
 #include <vector>
@@ -30,62 +31,14 @@ static constexpr float kMuzzleMinTiles    = 0.3f;
 static constexpr float kMuzzleMaxTiles    = 2.225f;
 static constexpr float kMuzzleVanillaEps  = 0.00051f; // treat as disabled vs 0.3
 
-// ProjectileProperties.Lifetime: usually seconds in XML; already-ms values are typically >= ~250.
-static float NormalizeLifetimeToMs(float rawFromProps)
-{
-    if (!(rawFromProps > 0.f) || rawFromProps != rawFromProps)
-        return 2000.f;
-    if (rawFromProps < 250.f)
-        return rawFromProps * 1000.f;
-    return rawFromProps;
-}
-
-// AccelDelay from ProjectileProperties: assembly confirms it is always a float in seconds,
-// compared against elapsed-time/1000 (i.e., t_s). Same heuristic threshold as Lifetime.
-static float NormalizeAccelDelayToMs(float raw)
-{
-    if (!(raw > 0.f) || raw != raw)
-        return 0.f;
-    if (raw < 250.f)          // < 250 → stored in seconds; >= 250 → already ms
-        return raw * 1000.f;
-    return raw;
-}
-
 namespace {
-
-// SpawnProjectileDetour uses SEH (__try). DBG_FILE_LOG builds a std::ostringstream
-// (object requiring unwinding), which MSVC forbids in the same function as __try
-// (C2712). Isolate the logging in noinline helpers — same pattern as
-// AutoAim::AutoAimLogRunning.
-__declspec(noinline) static void PtLogDetourFired(int count, int bulletId,
-                                                  int32_t attacker, uint32_t owner)
-{
-    DBG_FILE_LOG("[ProjectileTracking] detour FIRED (count=" << count
-        << " bulletId=" << bulletId << " attacker=" << attacker
-        << " owner=" << owner << ")");
-}
-__declspec(noinline) static void PtLogStored(uint32_t idx, int enemy,
-                                              float sx, float sy, int n)
-{
-    DBG_FILE_LOG("[ProjectileTracking] stored slot idx=" << idx
-        << " enemy=" << enemy << " pos=(" << sx << "," << sy << ")"
-        << " (storeCount=" << n << ")");
-}
-
-constexpr int           kMaxTrackedProj     = 256;
-
 static const char* kProjClassName   = "HBEAKBIHANL";
 static const char* kHbeakSpeedMulFieldName = "KDAJOMOFMJB"; // Flash speedMul_ equivalent (types.cs)
 static const char* kSpawnMethodName = "KOBMINBDOBD";
 static const int   kSpawnParamCount = 12;
 
-// The projectile class's BeeByte-obfuscated name changes every game update.
-// kProjClassName ("HBEAKBIHANL") is stale on the current build — proven by
-// dll-trace ("projectile class 'HBEAKBIHANL' UNRESOLVED"). BeebyteName.h is
-// auto-regenerated per build and maps obfuscated->readable; reverse-scan it
-// for the class whose readable name is "Projectile" to get the CURRENT
-// obfuscated name, then resolve. Falls back to the hardcoded name (keeps
-// older game builds / b0's setup working). Self-corrects on future updates.
+// Projectile's BeeByte-obfuscated class changes per build; resolve it from
+// readable metadata first, then fall back to the older hardcoded name.
 __declspec(noinline) static Il2CppClass* ResolveProjClass()
 {
     static Il2CppClass* s_cached = nullptr;
@@ -118,11 +71,6 @@ __declspec(noinline) static Il2CppClass* ResolveProjClass()
     }
     return s_cached;
 }
-constexpr float         kProjVisualTimeOffsetMs = 0.f;
-static const uint32_t& kOffWorldX = RuntimeOffsets::PosX;
-static const uint32_t& kOffWorldY = RuntimeOffsets::PosY;
-// HBEAKBIHANL.HHFDCMIIIHF (projRadius) — offset from RuntimeOffsets::Hbeak_ProjRadius (IL2CPP + BeeByte).
-
 using SpawnProjectileFn = void* (__fastcall*)(
     void*    projInstance,
     void*    objProps,
@@ -140,30 +88,12 @@ using SpawnProjectileFn = void* (__fastcall*)(
     void*    methodInfo);
 
 SpawnProjectileFn         g_OriginalSpawn = nullptr;
-CRITICAL_SECTION          g_RingCs;
 CRITICAL_SECTION          g_EntCs;
 std::atomic<int32_t>      g_LocalDictKey{ 0 };
-std::atomic<float>        g_MuzzleDbgSpawnX{ 0.f };
-std::atomic<float>        g_MuzzleDbgSpawnY{ 0.f };
-std::atomic<int>          g_MuzzleDbgHasSpawn{ 0 };
-std::atomic<bool>         g_ShowPaths{ false };
-std::atomic<bool>         g_ShowHitboxes{ false };
-std::atomic<uint32_t>     g_WriteIdx{ 0 };
-WorldProjectile           g_Slots[kMaxTrackedProj]{};
-
-constexpr int             kMaxLocalProj = 64;
-CRITICAL_SECTION          g_LocalCs;
-std::atomic<uint32_t>     g_LocalWriteIdx{ 0 };
-WorldProjectile           g_LocalSlots[kMaxLocalProj]{};
-bool                      g_LocalCsInit = false;
 
 std::unordered_map<int32_t, std::pair<float, float>> g_EntityPos;
 bool                      g_Installed = false;
-bool                      g_CsInit = false;
-
-// Hazard-spawn callback (DangerPlanner consumer). Stored behind g_RingCs.
-ProjectileTracking::HazardSpawnCb g_HazardCb = nullptr;
-void*                             g_HazardCbUser = nullptr;
+bool                      g_EntCsInit = false;
 
 std::atomic<uint32_t>     g_hbeakSpeedMulFieldOff{ 0 }; // 0 = unresolved
 
@@ -210,430 +140,6 @@ static float ComputeEffectiveSpeedMulFromInstance(void* hbeakInstance)
     return p;
 }
 
-// Linear accel from ProjectileProperties floats only (no motion heuristics).
-static float EffectiveProjectileLinearAccel(const WorldProjectile& proj)
-{
-    if (fabsf(proj.acceleration) > 1e-6f)
-        return proj.acceleration;
-    if (fabsf(proj.accelerationInv) > 1e-12f && std::isfinite(proj.accelerationInv))
-        return 1.f / proj.accelerationInv;
-    if (fabsf(proj.velocityChangeRate) > 1e-6f)
-        return proj.velocityChangeRate;
-    if (fabsf(proj.velocityChangeRateInv) > 1e-12f && std::isfinite(proj.velocityChangeRateInv))
-        return 1.f / proj.velocityChangeRateInv;
-    return 0.f;
-}
-
-// Accel used along the aim axis: props-derived, else implicit symmetric boomerang decel when XML omits Acceleration*.
-// (-2*speed/lifetime in raw speed units matches v→0 at t=lifetime/2 when integrated with /10000 scaling.)
-//
-// Boolean gate: the game applies acceleration only when BOTH IsAccelerating
-// (this type CAN accelerate) AND UseAcceleration (this shot DOES) are true.
-// Boomerangs are the exception — they use implicit decel even with the
-// flags off (the XML omits Acceleration*), preserved below.
-static float ResolvedLinearAccelForDistance(const WorldProjectile& proj)
-{
-    if (!proj.boomerang && !(proj.isAccelerating && proj.useAccel))
-        return 0.f;
-    float a = EffectiveProjectileLinearAccel(proj);
-    if (fabsf(a) <= 1e-6f && proj.boomerang
-        && proj.lifetime > 1e-3f && proj.speed > 1.f && proj.speed <= 50000.f)
-        a = -2.f * proj.speed / proj.lifetime;
-    return a;
-}
-
-// True when ResolvedLinearAccelForDistance is synthesizing the implicit
-// boomerang decel (XML omits Acceleration*). In that case the kinematic
-// integral naturally produces boomerang motion — apex at life/2, back to 0
-// at life — IF we skip the v=0 clamp inside IntegratedDistanceAlongAim AND
-// skip the explicit fold in ProjPosAt. Layering both on a clamped integral
-// double-counts the deceleration: at t=life/2 the fold returns 0 instead of
-// the apex distance, so the predictor places the bullet back at the spawn
-// origin during its peak — and the planner walks straight into it.
-static bool UsingImplicitBoomerangDecel(const WorldProjectile& proj)
-{
-    if (!proj.boomerang) return false;
-    if (fabsf(EffectiveProjectileLinearAccel(proj)) > 1e-6f) return false;
-    return (proj.lifetime > 1e-3f && proj.speed > 1.f && proj.speed <= 50000.f);
-}
-
-// Signed distance along the aim axis from t=0 to t=tMs (ms), with optional constant acceleration,
-// delay before accel applies, and SpeedClamp (max speed when accelerating, min speed when decelerating).
-static float IntegratedDistanceAlongAim(const WorldProjectile& proj, float tMs)
-{
-    if (tMs <= 0.f)
-        return 0.f;
-
-    const float speedMul = (proj.speedMul > 1e-6f && proj.speedMul < 100.f) ? proj.speedMul : 1.f;
-    const float baseSpeedTpMs = (proj.speed / 10000.f) * speedMul;
-
-    const float accelLinear = ResolvedLinearAccelForDistance(proj);
-    const bool useKinematic = fabsf(accelLinear) > 1e-6f;
-    if (!useKinematic)
-        return tMs * baseSpeedTpMs;
-
-    // Acceleration is a float in tiles/s² (assembly: movss, no divisor applied).
-    // Converting to tiles/ms² requires dividing by 1000² = 1,000,000.
-    // SpeedClamp is a float in tiles/s (same post-norm units as Speed/10).
-    // Converting to tiles/ms requires dividing by 1,000.
-    // AccelDelay is already normalised to ms by NormalizeAccelDelayToMs.
-    // Assembly also scales delay by 1/speedMul; approximate here.
-    //
-    // speedMul² on acceleration: speedMul time-dilates the bullet's motion, i.e.
-    // the bullet behaves as if real time t were replaced by t·N (N = speedMul).
-    // Then v₀ scales by N and a scales by N² because pos = v₀·N·t + ½·a·N²·t².
-    // The previous single-N scaling underscaled accel for shots with non-1.0
-    // speedMul, making accelerating shots predict too-flat trajectories.
-    const float accelTpMs2 = (accelLinear / 1000000.f) * speedMul * speedMul;
-    const float speedTpMs = baseSpeedTpMs;
-    const float delay = (proj.accelDelay > 0.f) ? proj.accelDelay / speedMul : 0.f;
-
-    if (tMs <= delay)
-        return tMs * speedTpMs;
-
-    const float d1 = delay * speedTpMs;
-    const float t2 = tMs - delay;
-    float d2 = speedTpMs * t2 + 0.5f * accelTpMs2 * t2 * t2;
-
-    if (proj.speedClamp > 0.f) {
-        const float clampTpMs = (proj.speedClamp / 1000.f) * speedMul;
-        if (accelTpMs2 > 1e-12f && clampTpMs > speedTpMs) {
-            const float tClamp = (clampTpMs - speedTpMs) / accelTpMs2;
-            if (tClamp > 0.f && t2 > tClamp) {
-                const float dPre = speedTpMs * tClamp + 0.5f * accelTpMs2 * tClamp * tClamp;
-                d2 = dPre + clampTpMs * (t2 - tClamp);
-            }
-        } else if (accelTpMs2 < -1e-12f && clampTpMs < speedTpMs && clampTpMs >= 0.f) {
-            const float tFloor = (speedTpMs - clampTpMs) / (-accelTpMs2);
-            if (tFloor > 0.f && t2 > tFloor) {
-                const float dToFloor = speedTpMs * tFloor + 0.5f * accelTpMs2 * tFloor * tFloor;
-                d2 = dToFloor + clampTpMs * (t2 - tFloor);
-            }
-        }
-    } else if (accelTpMs2 < 0.f && !UsingImplicitBoomerangDecel(proj)) {
-        // Decelerating shots stop at v=0; boomerangs reverse past v=0 (handled
-        // by the unclamped integral when implicit decel is active).
-        const float tStop = speedTpMs / (-accelTpMs2);
-        if (t2 > tStop)
-            d2 = speedTpMs * tStop + 0.5f * accelTpMs2 * tStop * tStop;
-    }
-
-    return d1 + d2;
-}
-
-// Matches Flash/Unity projectile motion along aim (with Exalt accel / clamp extensions).
-// Branch priority matches binary positionAt: Laser → IsWavy → IsParametric → IsTurning/isCircleTurnDelayed → linear.
-static void ProjPosAt(const WorldProjectile& proj, float tMs, float& outX, float& outY)
-{
-    static constexpr float kPI = 3.14159265358979323846f;
-
-    const float distance = IntegratedDistanceAlongAim(proj, tMs);
-
-    // Laser: BJLDGDKMPFL::positionAt always returns spawn origin regardless of time.
-    // The beam is a static capsule — the projectile instance never translates.
-    if (proj.laser && proj.laserDistance > 1e-4f) {
-        outX = proj.startX;
-        outY = proj.startY;
-        return;
-    }
-
-    if (proj.wavy) {
-        const float phaseParity = ((proj.bulletId % 2) == 0) ? 0.f : kPI;
-        if (proj.hasCustomAmplitude && proj.amplitude != 0.f) {
-            // Custom-amplitude wavy: lateral perpendicular offset using per-projectile
-            // Amplitude and Frequency fields. Same formula as the amplitude path below,
-            // just triggered by IsWavy + HasCustomAmplitude. Assembly: [ProjProps+0x1A0] != 0.
-            const float life = (proj.lifetime > 0.001f) ? proj.lifetime : 1.f;
-            const float lateral = proj.amplitude
-                * sinf(phaseParity + ((tMs / life) * proj.frequency * 2.f * kPI));
-            outX = proj.startX + distance * cosf(proj.angle) + lateral * cosf(proj.angle + kPI * 0.5f);
-            outY = proj.startY + distance * sinf(proj.angle) + lateral * sinf(proj.angle + kPI * 0.5f);
-        } else {
-            // Standard wavy: angle modulation with hardcoded Flash constants (π/64 amp, 6π/s freq).
-            const float effAngle = proj.angle + (kPI / 64.f)
-                * sinf(phaseParity + ((6.f * kPI * tMs) / 1000.f));
-            outX = proj.startX + distance * cosf(effAngle);
-            outY = proj.startY + distance * sinf(effAngle);
-        }
-        return;
-    }
-
-    if (proj.parametric) {
-        const float life = (proj.lifetime > 0.001f) ? proj.lifetime : 1.f;
-        const float ang8 = (tMs / life) * 2.f * kPI;
-        const float s1 = sinf(ang8) * (((proj.bulletId % 2) != 0) ? 1.f : -1.f);
-        const float s2 = sinf(2.f * ang8) * ((((proj.bulletId % 4) + 4) % 4) < 2 ? 1.f : -1.f);
-        const float sa = sinf(proj.angle), ca = cosf(proj.angle);
-        const float mag = proj.magnitude;
-        outX = proj.startX + ((s1 * ca) - (s2 * sa)) * mag;
-        outY = proj.startY + ((s1 * sa) + (s2 * ca)) * mag;
-        return;
-    }
-
-    // ── IsTurning / isCircleTurnDelayed: polar / spiral path ──
-    //
-    // Binary priority: after IsWavy and IsParametric. isCircleTurnDelayed enters
-    // this branch even when IsTurning=0 (verified in positionAt disassembly at 0x181101986).
-    //
-    // Non-circled (standard turning):
-    //   pos = origin + distance(t) × (cos(angle + turnAngle(t)), sin(angle + turnAngle(t)))
-    //
-    // Circled (isCircleTurnDelayed):
-    //   Pre-delay : straight line — pos = origin + kinematicDist(t) × direction
-    //   Post-delay: fixed orbit  — pos = origin + orbitRadius × (cos(angle + omega*(t−delay)), sin(...))
-    //   orbitRadius = kinematicDist(circleTurnDelay)  (confirmed: binary calls CHBDHBNBAOL() for this)
-    if ((proj.isTurning || proj.isCircleTurnDelayed) && proj.turnStopTime > 1.f) {
-        const float baseSpdTpMs = proj.speed / 10000.f * proj.speedMul;
-        const bool  useCircle = proj.isCircleTurnDelayed && fabsf(proj.circleTurnAngle) > 1e-8f;
-        const float effRate   = useCircle ? proj.circleTurnAngle : proj.turnRate;
-
-        if (fabsf(effRate) > 1e-8f) {
-            // Exalt XML semantics:
-            //   TurnRate (proj.turnRate)        — radians per 50 ms server tick
-            //   CircleTurnAngle (proj.circleTurnAngle) — total arc swept over turnStopTime ms
-            const float omega = useCircle
-                ? (proj.circleTurnAngle / proj.turnStopTime)
-                : (proj.turnRate / 50.f);                              // rad/ms
-            const float delayMs = useCircle ? proj.circleTurnDelay
-                                            : (proj.isTurningDelayed ? proj.turnRateDelay : 0.f);
-
-            const float dtArc = (tMs > delayMs) ? (tMs - delayMs) : 0.f;
-
-            // Circle pre-delay: bullet travels straight to the orbit entry point.
-            // Binary: xmm8 stays as kinematicDist(tMs) when time < circleTurnDelay.
-            if (useCircle && dtArc <= 0.f) {
-                outX = proj.startX + distance * cosf(proj.angle);
-                outY = proj.startY + distance * sinf(proj.angle);
-                return;
-            }
-
-            // Raw turn angle from constant angular velocity.
-            float turnAngle = omega * dtArc;
-
-            // Boomerang / accelerated-turn modifier (JOMFDAHJELJEff).
-            // When IsTurningAccelerated=0, this is a pass-through (no-op).
-            if (proj.isTurningAccelerated && dtArc > 0.f) {
-                const float tSec = dtArc / 1000.f;
-                if (tSec >= proj.turnAccelDelay && proj.turnAccelDelay >= 0.f) {
-                    const float dt = tSec - proj.turnAccelDelay;
-                    if (proj.turnAccelInv > 0.f) {
-                        const float clamp = fmaxf(proj.turnClamp, proj.turnRate) - proj.turnRate;
-                        const float threshold = clamp * proj.turnAccelInv;
-                        if (dt <= threshold)
-                            turnAngle += 0.5f * proj.turnAcceleration * dt * dt;
-                        else
-                            turnAngle += 0.5f * threshold * clamp + (dt - threshold) * clamp;
-                    } else if (proj.turnAccelInv < 0.f) {
-                        const float clamp = fminf(proj.turnClamp, proj.turnRate) - proj.turnRate;
-                        const float threshold = clamp * proj.turnAccelInv;
-                        if (dt <= threshold)
-                            turnAngle += 0.5f * proj.turnAcceleration * dt * dt;
-                        else
-                            turnAngle += 0.5f * threshold * clamp + (dt - threshold) * clamp;
-                    }
-                }
-            }
-
-            // TurnStopTime cap: game's TurnAngleAtTime returns 0 after TurnStopTime
-            // for the standard positionAt variant (forceAccel=false).
-            const bool pastTurnStop = proj.turnSnapsToStraight && dtArc > proj.turnStopTime;
-            if (pastTurnStop) {
-                // Compute the arc endpoint and continue straight from there.
-                const float capAngle = omega * proj.turnStopTime;
-                const float thetaCap = proj.angle + capAngle;
-                if (useCircle) {
-                    const float circR = IntegratedDistanceAlongAim(proj, delayMs);
-                    const float arcEndX = proj.startX + circR * cosf(thetaCap);
-                    const float arcEndY = proj.startY + circR * sinf(thetaCap);
-                    const float extraMs = dtArc - proj.turnStopTime;
-                    outX = arcEndX + extraMs * baseSpdTpMs * cosf(thetaCap);
-                    outY = arcEndY + extraMs * baseSpdTpMs * sinf(thetaCap);
-                } else {
-                    const float distCap = IntegratedDistanceAlongAim(proj, delayMs + proj.turnStopTime);
-                    const float arcEndX = proj.startX + distCap * cosf(thetaCap);
-                    const float arcEndY = proj.startY + distCap * sinf(thetaCap);
-                    const float extraMs = dtArc - proj.turnStopTime;
-                    outX = arcEndX + extraMs * baseSpdTpMs * cosf(thetaCap);
-                    outY = arcEndY + extraMs * baseSpdTpMs * sinf(thetaCap);
-                }
-                return;
-            }
-
-            const float theta = proj.angle + turnAngle;
-            if (useCircle) {
-                // Fixed-radius orbit: radius = distance traveled during the straight delay phase.
-                const float circR = IntegratedDistanceAlongAim(proj, delayMs);
-                outX = proj.startX + circR * cosf(theta);
-                outY = proj.startY + circR * sinf(theta);
-            } else {
-                // Spiral: distance grows while angle rotates.
-                const float dist = IntegratedDistanceAlongAim(proj, tMs);
-                outX = proj.startX + dist * cosf(theta);
-                outY = proj.startY + dist * sinf(theta);
-            }
-            return;
-        }
-    }
-
-    float foldedDistance = distance;
-    // Only fold for boomerangs that have an *explicit* XML-provided accel —
-    // those still travel forward then return via the mirror trick. Boomerangs
-    // using implicit symmetric decel reverse on their own through the
-    // unclamped kinematic integral; folding them double-counts and predicts
-    // the bullet back at origin during its apex.
-    if (proj.boomerang && !UsingImplicitBoomerangDecel(proj)) {
-        const float life = (proj.lifetime > 1e-3f) ? proj.lifetime : 1.f;
-        const float maxAlong = IntegratedDistanceAlongAim(proj, life);
-        const float halfDist = maxAlong * 0.5f;
-        if (foldedDistance > halfDist)
-            foldedDistance = halfDist - (foldedDistance - halfDist);
-    }
-
-    outX = proj.startX + foldedDistance * cosf(proj.angle);
-    outY = proj.startY + foldedDistance * sinf(proj.angle);
-
-    if (proj.amplitude != 0.f) {
-        const float life = (proj.lifetime > 0.001f) ? proj.lifetime : 1.f;
-        const float phaseParity = ((proj.bulletId % 2) == 0) ? 0.f : kPI;
-        const float lateral = proj.amplitude
-            * sinf(phaseParity + ((tMs / life) * proj.frequency * 2.f * kPI));
-        outX += lateral * cosf(proj.angle + kPI * 0.5f);
-        outY += lateral * sinf(proj.angle + kPI * 0.5f);
-    }
-}
-
-static void TryReadRuntimeChebyshevT(void* projInst, float& outT)
-{
-    outT = 0.f;
-    if (!AddrOk(projInst)) return;
-    const uint32_t off = RuntimeOffsets::Hbeak_ProjRadius;
-    if (off == 0u || off >= 0x8000u) return;
-    __try {
-        float t = *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(projInst) + off);
-        if (t > 1e-4f && t < 16.f && std::isfinite(t)) outT = t;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-}
-
-// One-shot offset diagnostic. Dumps the first 12 enemy projectiles seen
-// along with attackerObjId (so we can confirm shot diversity), named KJ
-// sprite fields, every float between +0x040 and +0x200 on the HBEAK
-// instance, and the first 0x120 bytes of projProps as floats. The real
-// per-type size field will be the column whose values vary across
-// different attackers.
-static std::atomic<int> g_offsetLogCount{ 0 };
-
-static void LogOffsetDiagnostic(void* projInst, int32_t bulletId,
-                                int32_t attackerObjId, uint32_t ownerObjId,
-                                float projHalfSize, float runtimeT,
-                                float collMult, void* projPropsPtr,
-                                bool hasCustomHitbox,
-                                float customOffsetX, float customOffsetY,
-                                bool isEnemyShot)
-{
-#ifndef _DEBUG
-    // Investigation complete (see comment block at the per-type section
-    // of this file). Compiled out in Release so we don't pay fopen/fprintf
-    // on the spawn detour for every enemy shot during the first 12 fires
-    // of every session, and so customer machines don't get %TEMP% spam.
-    (void)projInst; (void)bulletId; (void)attackerObjId; (void)ownerObjId;
-    (void)projHalfSize; (void)runtimeT; (void)collMult; (void)projPropsPtr;
-    (void)hasCustomHitbox; (void)customOffsetX; (void)customOffsetY;
-    (void)isEnemyShot;
-    return;
-#else
-    if (!isEnemyShot) return;
-    const int n = g_offsetLogCount.fetch_add(1, std::memory_order_relaxed);
-    if (n >= 12) return;
-
-    char path[MAX_PATH] = {};
-    DWORD tmpLen = GetTempPathA(MAX_PATH, path);
-    if (tmpLen == 0 || tmpLen >= MAX_PATH) return;
-    strncat_s(path, sizeof(path), "LFG-offset-diag.log", _TRUNCATE);
-
-    FILE* f = nullptr;
-    if (fopen_s(&f, path, "a") != 0 || !f) return;
-
-    if (n == 0) {
-        fprintf(f,
-            "=== LFG dodge-offset diagnostic (v2) ===\n"
-            "Resolved: Hbeak_ProjRadius=0x%X  KJ_BaseRadius=0x%X  KJ_Scale=0x%X  KJ_SkinWidthObj=0x%X  PP_CollMult=0x%X\n"
-            "Looking for: a field whose value differs between bullets fired by DIFFERENT attackerObjIds.\n"
-            "A real per-type T is in the 0.05-0.7 range. The field we're currently using (0x1D4)\n"
-            "always reads 0.5, which means it's a constant, not per-type T.\n\n",
-            static_cast<unsigned>(RuntimeOffsets::Hbeak_ProjRadius),
-            static_cast<unsigned>(RuntimeOffsets::KJ_BaseRadius),
-            static_cast<unsigned>(RuntimeOffsets::KJ_Scale),
-            static_cast<unsigned>(RuntimeOffsets::KJ_SkinWidthObj),
-            static_cast<unsigned>(RuntimeOffsets::PP_CollMult));
-    }
-
-    // HBEAK instance dump: +0x040 .. +0x200  (448 bytes = 112 floats).
-    constexpr int kHBeakStart = 0x040;
-    constexpr int kHBeakCount = (0x200 - 0x040) / 4;
-    float hb[kHBeakCount] = { 0 };
-    float kjBaseR = 0.f, kjScale = 0.f, kjSkin = 0.f;
-    if (AddrOk(projInst)) {
-        __try {
-            uint8_t* b = reinterpret_cast<uint8_t*>(projInst);
-            for (int i = 0; i < kHBeakCount; ++i) {
-                hb[i] = *reinterpret_cast<float*>(b + kHBeakStart + i * 4);
-            }
-            if (RuntimeOffsets::KJ_BaseRadius  && RuntimeOffsets::KJ_BaseRadius  < 0x8000)
-                kjBaseR = *reinterpret_cast<float*>(b + RuntimeOffsets::KJ_BaseRadius);
-            if (RuntimeOffsets::KJ_Scale       && RuntimeOffsets::KJ_Scale       < 0x8000)
-                kjScale = *reinterpret_cast<float*>(b + RuntimeOffsets::KJ_Scale);
-            if (RuntimeOffsets::KJ_SkinWidthObj && RuntimeOffsets::KJ_SkinWidthObj < 0x8000)
-                kjSkin  = *reinterpret_cast<float*>(b + RuntimeOffsets::KJ_SkinWidthObj);
-        } __except (EXCEPTION_EXECUTE_HANDLER) {}
-    }
-
-    // projProps dump: +0x000 .. +0x120 (288 bytes = 72 floats).
-    constexpr int kPpCount = 0x120 / 4;
-    float pp[kPpCount] = { 0 };
-    if (AddrOk(projPropsPtr)) {
-        __try {
-            uint8_t* ppb = reinterpret_cast<uint8_t*>(projPropsPtr);
-            for (int i = 0; i < kPpCount; ++i) {
-                pp[i] = *reinterpret_cast<float*>(ppb + i * 4);
-            }
-        } __except (EXCEPTION_EXECUTE_HANDLER) {}
-    }
-
-    fprintf(f,
-        "bullet[%2d] id=%d  attackerObjId=%d  ownerObjId=%u\n"
-        "            projHalfSize=%.4f  runtimeT(0x%X)=%.4f  collMult=%.4f  hasCustomHitbox=%d  customOff=(%.4f,%.4f)\n"
-        "            KJ_BaseRadius(0x%X)=%.4f  KJ_Scale(0x%X)=%.4f  KJ_SkinWidthObj(0x%X)=%.4f\n",
-        n, bulletId, attackerObjId, ownerObjId,
-        projHalfSize,
-        static_cast<unsigned>(RuntimeOffsets::Hbeak_ProjRadius), runtimeT,
-        collMult, hasCustomHitbox ? 1 : 0, customOffsetX, customOffsetY,
-        static_cast<unsigned>(RuntimeOffsets::KJ_BaseRadius),  kjBaseR,
-        static_cast<unsigned>(RuntimeOffsets::KJ_Scale),       kjScale,
-        static_cast<unsigned>(RuntimeOffsets::KJ_SkinWidthObj), kjSkin);
-
-    fprintf(f, "    HBEAK +0x%03X..+0x%03X (non-zero plausible-T entries flagged):\n",
-        kHBeakStart, kHBeakStart + kHBeakCount * 4 - 4);
-    for (int i = 0; i < kHBeakCount; ++i) {
-        const uint32_t off = kHBeakStart + i * 4;
-        const float v = hb[i];
-        if (fabsf(v) < 1e-6f) continue;     // skip zeros — keeps log readable
-        const char* flag = (std::isfinite(v) && v > 1e-4f && v < 2.f) ? " <-- plausible T" : "";
-        fprintf(f, "        +0x%03X = %12.4f%s\n", off, v, flag);
-    }
-    fprintf(f, "    projProps +0x000..+0x%03X (non-zero flagged):\n", kPpCount * 4 - 4);
-    for (int i = 0; i < kPpCount; ++i) {
-        const uint32_t off = i * 4;
-        const float v = pp[i];
-        if (fabsf(v) < 1e-6f) continue;
-        const char* flag = (std::isfinite(v) && v > 1e-4f && v < 2.f) ? " <-- plausible T" : "";
-        fprintf(f, "        +0x%03X = %12.4f%s\n", off, v, flag);
-    }
-    fprintf(f, "\n");
-    fclose(f);
-#endif // _DEBUG
-}
-
-
 static bool TryReadLivePos(void* projInst, float& outX, float& outY)
 {
     outX = 0.f;
@@ -641,8 +147,8 @@ static bool TryReadLivePos(void* projInst, float& outX, float& outY)
     if (!AddrOk(projInst)) return false;
     __try {
         uint8_t* p = reinterpret_cast<uint8_t*>(projInst);
-        outX = *reinterpret_cast<float*>(p + kOffWorldX);
-        outY = *reinterpret_cast<float*>(p + kOffWorldY);
+        outX = *reinterpret_cast<float*>(p + RuntimeOffsets::PosX);
+        outY = *reinterpret_cast<float*>(p + RuntimeOffsets::PosY);
         return true;
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         return false;
@@ -669,17 +175,15 @@ static void LookupShooterOrigin(int32_t attackerObjId, uint32_t ownerObjId, floa
     LeaveCriticalSection(&g_EntCs);
 }
 
-// Spawn often passes a shared ProjectileProperties template; the live per-shot copy is
-// HBEAKBIHANL.FOMOIBCKIFP @ 0x118 (Il2CppInspector).
-static void* EffectiveProjPropsFromHbeak(void* hbeak, void* argProjProps)
+static bool TryReadObjectPropertiesIsEnemy(void* objProps, bool& outIsEnemy)
 {
-    if (AddrOk(hbeak)) {
-        __try {
-            void* p118 = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(hbeak) + RuntimeOffsets::Hbeak_ProjPropsPtr);
-            if (AddrOk(p118)) return p118;
-        } __except (EXCEPTION_EXECUTE_HANDLER) {}
-    }
-    return argProjProps;
+    outIsEnemy = false;
+    if (!AddrOk(objProps)) return false;
+    __try {
+        outIsEnemy = *reinterpret_cast<bool*>(reinterpret_cast<uint8_t*>(objProps) + RuntimeOffsets::OP_IsEnemy);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    return false;
 }
 
 void* __fastcall SpawnProjectileDetour(
@@ -698,21 +202,6 @@ void* __fastcall SpawnProjectileDetour(
     bool     isAbility,
     void*    methodInfo)
 {
-    (void)objProps;
-    (void)name;
-    (void)group;
-    (void)canHitPlayer;
-    (void)projInstance;
-
-    {
-        // Proves the spawn hook is installed AND the game is calling it. No
-        // "detour FIRED" lines while bullets fly → wrong function hooked.
-        // FIRED but XDodge projs=0 → failure is downstream (store/filter).
-        static int s_n = 0;
-        if ((s_n++ % 120) == 0)
-            PtLogDetourFired(s_n, bulletId, attackerObjId, ownerObjId);
-    }
-
     RuntimeOffsets::EnsureAll();
 
     float spawnX = startX;
@@ -777,7 +266,11 @@ void* __fastcall SpawnProjectileDetour(
     if (!AddrOk(ret))
         return ret;
 
-    const bool isEnemyShot = !isLocalShot;
+    bool ownerIsEnemy = false;
+    const bool ownerClassified = TryReadObjectPropertiesIsEnemy(objProps, ownerIsEnemy);
+    const bool isEnemyShot = !isLocalShot && ((ownerClassified && ownerIsEnemy) || (!ownerClassified && canHitPlayer));
+    if (!isLocalShot && !isEnemyShot)
+        return ret;
 
     float entityX = 0.f, entityY = 0.f;
     LookupShooterOrigin(attackerObjId, ownerObjId, entityX, entityY);
@@ -798,31 +291,13 @@ void* __fastcall SpawnProjectileDetour(
         }
     }
 
-    CRITICAL_SECTION* cs;
-    WorldProjectile*  slots;
-    uint32_t          maxSlots;
-    std::atomic<uint32_t>* writeIdx;
-    if (isEnemyShot) {
-        cs = &g_RingCs; slots = g_Slots; maxSlots = kMaxTrackedProj; writeIdx = &g_WriteIdx;
-    } else {
-        if (!g_LocalCsInit) { InitializeCriticalSection(&g_LocalCs); g_LocalCsInit = true; }
-        cs = &g_LocalCs; slots = g_LocalSlots; maxSlots = kMaxLocalProj; writeIdx = &g_LocalWriteIdx;
-    }
-
-    EnterCriticalSection(cs);
-    const uint32_t idx = writeIdx->fetch_add(1, std::memory_order_relaxed) % maxSlots;
-    WorldProjectile& p = slots[idx];
-    memset(&p, 0, sizeof(p));
+    WorldProjectile p{};
     p.startX = sx;
     p.startY = sy;
-    if (!isEnemyShot) {
-        g_MuzzleDbgSpawnX.store(sx, std::memory_order_relaxed);
-        g_MuzzleDbgSpawnY.store(sy, std::memory_order_relaxed);
-        g_MuzzleDbgHasSpawn.store(1, std::memory_order_relaxed);
-    }
     p.angle = angle;
     p.spawnTick = spawnTickPre;
     p.valid = true;
+    p.canHitPlayer = canHitPlayer;
     p.ptr = ret;
     p.bulletId = bulletId;
     p.attackerObjId = attackerObjId;
@@ -840,129 +315,17 @@ void* __fastcall SpawnProjectileDetour(
     p.accelDelay = 0.f;
     p.speedClamp = 0.f;
     p.projPropsPtr = nullptr;
+    p.x = sx;
+    p.y = sy;
 
-    void* const ppEffective = EffectiveProjPropsFromHbeak(ret, projProps);
-    if (AddrOk(ppEffective)) {
-        __try {
-            p.projPropsPtr = ppEffective;
-            uint8_t* pp = reinterpret_cast<uint8_t*>(ppEffective);
-            float rawLifetime = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Lifetime);
-            p.lifetime      = NormalizeLifetimeToMs(rawLifetime);
-            p.speed = static_cast<float>(*reinterpret_cast<int32_t*>(pp + RuntimeOffsets::PP_Speed));
-            p.wavy = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsWavy);
-            p.hasCustomAmplitude = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_HasCustomAmplitude);
-            p.boomerang = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsBoomerang);
-            p.parametric = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsParametric);
-            p.frequency = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Frequency);
-            p.amplitude = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Amplitude);
-            p.minDamage = *reinterpret_cast<int32_t*>(pp + RuntimeOffsets::PP_MinDamage);
-            p.damage = *reinterpret_cast<int32_t*>(pp + RuntimeOffsets::PP_MaxDamage);
-            const float rawDelayF = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_AccelDelay);
-            const float rawAccelF = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Acceleration);
-            p.isAccelerating = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsAccel);
-            p.useAccel       = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_UseAccel);
-            p.acceleration = rawAccelF;
-            p.accelerationInv = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_AccelerationInv);
-            p.velocityChangeRate = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_VelocityChangeRate);
-            p.velocityChangeRateInv = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_VelocityChangeRateInv);
-            p.accelDelay = NormalizeAccelDelayToMs(rawDelayF);
-            p.speedClamp = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_SpeedClamp);
-
-            // Per-type collision half-edge. Diagnostic log (%TEMP%\LFG-
-            // offset-diag.log) confirmed on this build:
-            //   * runtimeChebyshevHalf at HBEAK+0x1D4 is ALWAYS 0.5 — a
-            //     static class constant, not per-bullet T.
-            //   * collMult (PP+0xC0) is ALWAYS 1.0 for enemy shots.
-            //   * KJ_BaseRadius × KJ_Scale at HBEAK+0x44 × +0x74 correctly
-            //     differentiates per enemy type (e.g. 0.5×1.0=0.5 for a
-            //     big-shot mob, 0.5×0.7=0.35 for a smaller one).
-            // So sprite-derived product is the real source on this build;
-            // the old collMult fallback treated every bullet as the same
-            // huge size and over-stamped the planner.
-            float collMult = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_CollMult);
-            if (!std::isfinite(collMult) || collMult <= 0.f || collMult > 20.f) collMult = 1.0f;
-            float projectileMagnitude = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Magnitude);
-            p.magnitude = projectileMagnitude;
-
-            float kjBaseR = 0.f, kjScale = 0.f;
-            if (AddrOk(ret)) {
-                __try {
-                    uint8_t* rb = reinterpret_cast<uint8_t*>(ret);
-                    if (RuntimeOffsets::KJ_BaseRadius && RuntimeOffsets::KJ_BaseRadius < 0x8000)
-                        kjBaseR = *reinterpret_cast<float*>(rb + RuntimeOffsets::KJ_BaseRadius);
-                    if (RuntimeOffsets::KJ_Scale && RuntimeOffsets::KJ_Scale < 0x8000)
-                        kjScale = *reinterpret_cast<float*>(rb + RuntimeOffsets::KJ_Scale);
-                } __except (EXCEPTION_EXECUTE_HANDLER) {}
-            }
-            if (std::isfinite(kjBaseR) && kjBaseR > 0.01f && kjBaseR < 4.f &&
-                std::isfinite(kjScale) && kjScale > 0.01f && kjScale < 20.f) {
-                p.projHalfSize = kjBaseR * kjScale;
-            } else {
-                p.projHalfSize = collMult * 0.5f;   // last-resort fallback
-            }
-
-            float laserDist = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_LaserDist);
-            p.laserDistance = (laserDist > 1e-4f && std::isfinite(laserDist)) ? laserDist : 0.f;
-            p.laser = p.laserDistance > 1e-3f;
-            p.isTurning = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsTurning);
-            // PP[IsTurning+1]: "circle-turn delayed" flag (LDONHCKAFIA assembly, PP[0x1B1]).
-            p.isCircleTurnDelayed = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsTurning + 1);
-            p.isTurningDelayed = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsTurningDelayed);
-            // PP[IsTurning+5]: snap-to-straight flag (LDONHCKAFIA assembly, PP[0x1B5]).
-            // When 0 (common), arc continues past TurnStopTime for the full lifetime.
-            p.turnSnapsToStraight = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsTurning + 5);
-            p.isTurningAccelerated = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsTurning + 3);
-            p.turnRate = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_TurnRate);
-            if (!std::isfinite(p.turnRate)) p.turnRate = 0.f;
-            {
-                const float rawTurnStopTime = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_TurnStopTime);
-                p.turnStopTime = (std::isfinite(rawTurnStopTime) && rawTurnStopTime > 0.f) ? rawTurnStopTime : 0.f;
-                const float rawTurnRateDelay = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_TurnRateDelay);
-                p.turnRateDelay = NormalizeAccelDelayToMs(rawTurnRateDelay);
-                const float rawCircleAngle = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_CircleTurnAngle);
-                p.circleTurnAngle = std::isfinite(rawCircleAngle) ? rawCircleAngle : 0.f;
-                const float rawCircleDelay = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_CircleTurnDelay);
-                p.circleTurnDelay = (std::isfinite(rawCircleDelay) && rawCircleDelay > 0.f) ? rawCircleDelay : 0.f;
-                const float rawTurnAccel = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_TurnAcceleration);
-                p.turnAcceleration = std::isfinite(rawTurnAccel) ? rawTurnAccel : 0.f;
-                const float rawTurnAccelDelay = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_TurnAccelDelay);
-                p.turnAccelDelay = std::isfinite(rawTurnAccelDelay) ? rawTurnAccelDelay : 0.f;
-                const float rawTurnClamp = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_TurnClamp);
-                p.turnClamp = std::isfinite(rawTurnClamp) ? rawTurnClamp : 0.f;
-                const float rawTurnAccelInv = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_TurnAccelInv);
-                p.turnAccelInv = std::isfinite(rawTurnAccelInv) ? rawTurnAccelInv : 0.f;
-            }
-            bool hasCustomHitbox = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_HasCustomHitbox);
-            p.hasCustomHitbox = hasCustomHitbox;
-
-            if (hasCustomHitbox) {
-                void* customHitbox = *reinterpret_cast<void**>(pp + RuntimeOffsets::PP_CustomHitbox);
-                if (AddrOk(customHitbox)) {
-                    uint8_t* ch = reinterpret_cast<uint8_t*>(customHitbox);
-                    float offX = *reinterpret_cast<float*>(ch + RuntimeOffsets::CH_OffsetX);
-                    float offY = *reinterpret_cast<float*>(ch + RuntimeOffsets::CH_OffsetY);
-                    p.customOffsetX = offX;
-                    p.customOffsetY = offY;
-                    float hx = fabsf(offX), hy = fabsf(offY);
-                    p.projHalfSize = (hx > hy) ? hx : hy;
-                }
-            }
-
-            TryReadRuntimeChebyshevT(ret, p.runtimeChebyshevHalf);
-            LogOffsetDiagnostic(ret, p.bulletId, p.attackerObjId, ownerObjId,
-                                p.projHalfSize, p.runtimeChebyshevHalf,
-                                collMult, pp,
-                                p.hasCustomHitbox, p.customOffsetX, p.customOffsetY,
-                                isEnemyShot);
-
-            if (p.speed < 1.f || p.speed > 50000.f || p.lifetime < 50.f || p.lifetime > 600000.f) {
-                p.speed = 5000.f;
-                p.lifetime = 2000.f;
-                p.minDamage = 100;
-                p.damage = 100;
-            }
-
-        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    void* const ppEffective = ProjectileRuntimeReader::EffectivePropsFromProjectile(ret, projProps);
+    if (ProjectileRuntimeReader::ApplyProperties(p, ret, ppEffective, ProjectileCollisionFallback::SpawnHook)) {
+        if (p.speed < 1.f || p.speed > 50000.f || p.lifetime < 50.f || p.lifetime > 600000.f) {
+            p.speed = 5000.f;
+            p.lifetime = 2000.f;
+            p.minDamage = 100;
+            p.damage = 100;
+        }
     }
 
     p.speedMul = ComputeEffectiveSpeedMulFromInstance(ret);
@@ -970,119 +333,37 @@ void* __fastcall SpawnProjectileDetour(
     if (AddrOk(ret)) {
         __try {
             uint8_t* pi = reinterpret_cast<uint8_t*>(ret);
-            p.x = *reinterpret_cast<float*>(pi + kOffWorldX);
-            p.y = *reinterpret_cast<float*>(pi + kOffWorldY);
+            p.x = *reinterpret_cast<float*>(pi + RuntimeOffsets::PosX);
+            p.y = *reinterpret_cast<float*>(pi + RuntimeOffsets::PosY);
         } __except (EXCEPTION_EXECUTE_HANDLER) {
-            ProjPosAt(p, 0.f, p.x, p.y);
+            float posX = p.x;
+            float posY = p.y;
+            if (ProjectileTrajectory::GetPositionAtTime(p, 0.f, posX, posY)) {
+                p.x = posX;
+                p.y = posY;
+            }
         }
     } else {
-        ProjPosAt(p, 0.f, p.x, p.y);
+        float posX = p.x;
+        float posY = p.y;
+        if (ProjectileTrajectory::GetPositionAtTime(p, 0.f, posX, posY)) {
+            p.x = posX;
+            p.y = posY;
+        }
     }
 
-    // Snapshot the slot (still under lock) for the hazard-spawn callback so the
-    // DangerPlanner can trigger a replan on new enemy shots inside its horizon.
-    const bool    callCallback = isEnemyShot;
-    WorldProjectile snap;
-    if (callCallback) {
-        snap = p;
-    }
+    ProjectileTrajectory::CachePath(p);
 
-    LeaveCriticalSection(cs);
-
-    {
-        // enemy=1 entries land in g_Slots[] — exactly what XDodge's
-        // CopyActiveForDraw reads. enemy=1 here but XDodge projs=0 → the
-        // CopyActiveForDraw lifetime/elapsed filter is dropping them.
-        static int s_n = 0;
-        if ((s_n++ % 120) == 0)
-            PtLogStored(idx, (int)isEnemyShot, sx, sy, s_n);
-    }
-
-    if (callCallback) {
+    const WorldProjectile snap = ProjectileStore::StoreProjectile(isEnemyShot, p);
+    if (isEnemyShot) {
         // Seed per-dungeon type catalog (debug viz only — planner doesn't read).
         // Owner type passed as 0 here; resolution from WorldTAB is done later by
         // debug tools that care. Same-bullet/0-owner entries deduplicate safely.
         ProjectileCatalog::RecordSpawn(0, snap);
-
-        ProjectileTracking::HazardSpawnCb cb = nullptr;
-        void* user = nullptr;
-        {
-            EnterCriticalSection(&g_RingCs);
-            cb   = g_HazardCb;
-            user = g_HazardCbUser;
-            LeaveCriticalSection(&g_RingCs);
-        }
-        if (cb) {
-            __try {
-                cb(snap, user);
-            } __except (EXCEPTION_EXECUTE_HANDLER) {}
-        }
+        ProjectileStore::NotifyHazardSpawn(snap);
     }
 
     return ret;
-}
-
-static void RefreshMotionFromProjProps(WorldProjectile& dst, void* projPropsPtr)
-{
-    if (!AddrOk(projPropsPtr)) return;
-    __try {
-        uint8_t* pp = reinterpret_cast<uint8_t*>(projPropsPtr);
-        dst.acceleration = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Acceleration);
-        dst.accelerationInv = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_AccelerationInv);
-        dst.velocityChangeRate = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_VelocityChangeRate);
-        dst.velocityChangeRateInv = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_VelocityChangeRateInv);
-        dst.accelDelay = NormalizeAccelDelayToMs(*reinterpret_cast<float*>(pp + RuntimeOffsets::PP_AccelDelay));
-        dst.speedClamp = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_SpeedClamp);
-        dst.isAccelerating = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsAccel);
-        dst.useAccel       = *reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_UseAccel);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-}
-
-static void FillOutFromSlot(WorldProjectile& dst, const WorldProjectile& src, ULONGLONG now, bool livePos)
-{
-    dst = src;
-    if (!src.valid) return;
-    RefreshMotionFromProjProps(dst, src.projPropsPtr);
-    if (AddrOk(src.ptr)) {
-        float rt = 0.f;
-        TryReadRuntimeChebyshevT(src.ptr, rt);
-        dst.runtimeChebyshevHalf = (rt > 1e-5f) ? rt : src.runtimeChebyshevHalf;
-    }
-    float elapsed = static_cast<float>(now - src.spawnTick);
-    if (livePos && AddrOk(src.ptr) && TryReadLivePos(src.ptr, dst.x, dst.y)) {
-        // Re-anchor startX/startY so ComputePosAt stays consistent with the live
-        // position. Without this, stale entity positions at spawn time cause
-        // predicted positions to drift far from reality.
-        //
-        // Exception: parametric shots use startX/Y as the orbit CENTER — shifting
-        // it by the instantaneous orbit displacement would move the entire circle
-        // each frame, making future predictions wrong.
-        // Same applies to ALL turning variants (isTurning / isCircleTurnDelayed /
-        // isTurningDelayed / isTurningAccelerated) — the spiral/arc math at the
-        // top of ComputePosAt uses startX/Y as the rotation center, so per-frame
-        // re-anchoring walks the spiral around the live position and every
-        // future-tick prediction lands in the wrong place.
-        // Lasers are stationary (BJLDGDKMPFL::positionAt always returns spawn origin),
-        // and dodge code never uses ComputePosAt for them — DangerMap stamps the beam
-        // as a capsule and PrecisionDodge does its own line-distance check. Skipping
-        // the re-anchor keeps startX as the beam's true emitter origin.
-        const bool reAnchorSafe = !src.parametric && !src.laser
-            && !src.isTurning && !src.isCircleTurnDelayed
-            && !src.isTurningDelayed && !src.isTurningAccelerated;
-        if (reAnchorSafe && elapsed >= 0.f) {
-            float predX, predY;
-            ProjPosAt(dst, elapsed, predX, predY);
-            dst.startX += (dst.x - predX);
-            dst.startY += (dst.y - predY);
-        }
-        return;
-    }
-    if (elapsed >= 0.f)
-        ProjPosAt(dst, elapsed + kProjVisualTimeOffsetMs, dst.x, dst.y);
-    else {
-        dst.x = src.x;
-        dst.y = src.y;
-    }
 }
 
 } // namespace
@@ -1100,10 +381,10 @@ void Install()
             DBG_FILE_LOG("[ProjectileTracking] Install() reached, not yet installed "
                 "(attempt=" << s_n << ") — resolving hook target...");
     }
-    if (!g_CsInit) {
-        InitializeCriticalSection(&g_RingCs);
+    ProjectileStore::Initialize();
+    if (!g_EntCsInit) {
         InitializeCriticalSection(&g_EntCs);
-        g_CsInit = true;
+        g_EntCsInit = true;
     }
 
     Il2CppClass* klass = ResolveProjClass();
@@ -1148,6 +429,11 @@ void Install()
     DBG_FILE_LOG("[ProjectileTracking] Install: spawn hook INSTALLED — bullets now captured");
 }
 
+bool IsInstalled()
+{
+    return g_Installed;
+}
+
 void Uninstall()
 {
     if (g_Installed) {
@@ -1159,19 +445,21 @@ void Uninstall()
         g_spawnTarget = nullptr;
         g_Installed = false;
     }
-    if (g_CsInit) {
-        DeleteCriticalSection(&g_RingCs);
+    ProjectileStore::Shutdown();
+    if (g_EntCsInit) {
         DeleteCriticalSection(&g_EntCs);
-        g_CsInit = false;
+        g_EntCsInit = false;
     }
 }
 
 void ComputePosAtSafe(const WorldProjectile& proj, float tMs, float& outX, float& outY)
 {
-    outX = 0.f;
-    outY = 0.f;
-    __try { ComputePosAt(proj, tMs, outX, outY); }
-    __except (EXCEPTION_EXECUTE_HANDLER) {}
+    const float fallbackX = outX;
+    const float fallbackY = outY;
+    if (!ProjectileTrajectory::GetPositionAtTime(proj, tMs, outX, outY)) {
+        outX = fallbackX;
+        outY = fallbackY;
+    }
 }
 
 void SetLocalPlayerObjectId(int32_t objectId)
@@ -1184,17 +472,9 @@ int32_t GetLocalPlayerObjectId()
     return g_LocalDictKey.load(std::memory_order_relaxed);
 }
 
-bool GetMuzzleDebugLastSpawn(float& outWorldX, float& outWorldY)
-{
-    if (!g_MuzzleDbgHasSpawn.load(std::memory_order_relaxed))
-        return false;
-    outWorldX = g_MuzzleDbgSpawnX.load(std::memory_order_relaxed);
-    outWorldY = g_MuzzleDbgSpawnY.load(std::memory_order_relaxed);
-    return std::isfinite(outWorldX) && std::isfinite(outWorldY);
-}
-
 void OnWorldRefreshBegin()
 {
+    if (!g_EntCsInit) return;
     EnterCriticalSection(&g_EntCs);
     g_EntityPos.clear();
     LeaveCriticalSection(&g_EntCs);
@@ -1202,113 +482,40 @@ void OnWorldRefreshBegin()
 
 void OnWorldEntity(int32_t objectId, float x, float y)
 {
+    if (!g_EntCsInit) return;
     EnterCriticalSection(&g_EntCs);
     g_EntityPos[objectId] = { x, y };
     LeaveCriticalSection(&g_EntCs);
 }
 
-void SetVisualFlags(bool showPaths, bool showHitboxes)
-{
-    g_ShowPaths.store(showPaths, std::memory_order_relaxed);
-    g_ShowHitboxes.store(showHitboxes, std::memory_order_relaxed);
-}
-
-bool ShowPaths() { return g_ShowPaths.load(std::memory_order_relaxed); }
-bool ShowHitboxes() { return g_ShowHitboxes.load(std::memory_order_relaxed); }
-
 void SnapshotToWorld(std::vector<WorldProjectile>& out)
 {
-    out.clear();
-    const ULONGLONG now = GetTickCount64();
-    EnterCriticalSection(&g_RingCs);
-    for (int i = 0; i < kMaxTrackedProj; ++i) {
-        const WorldProjectile& s = g_Slots[i];
-        if (!s.valid) continue;
-        float elapsed = static_cast<float>(now - s.spawnTick);
-        if (s.lifetime > 0.f && elapsed >= s.lifetime) continue;
-
-        WorldProjectile row;
-        FillOutFromSlot(row, s, now, true);
-        out.push_back(row);
-    }
-    LeaveCriticalSection(&g_RingCs);
+    ProjectileStore::SnapshotToWorld(out);
 }
 
 void CopyActiveForDraw(std::vector<WorldProjectile>& out)
 {
-    out.clear();
-    const ULONGLONG now = GetTickCount64();
-    int dbgValid = 0, dbgExpired = 0, dbgFuture = 0;
-    EnterCriticalSection(&g_RingCs);
-    for (int i = 0; i < kMaxTrackedProj; ++i) {
-        const WorldProjectile& s = g_Slots[i];
-        if (!s.valid) continue;
-        ++dbgValid;
-        float elapsed = static_cast<float>(now - s.spawnTick);
-        float elapsedViz = elapsed + kProjVisualTimeOffsetMs;
-        if (elapsedViz < 0.f) { ++dbgFuture; continue; }
-        if (s.lifetime > 0.f && elapsedViz >= s.lifetime) { ++dbgExpired; continue; }
-
-        WorldProjectile row;
-        FillOutFromSlot(row, s, now, true);
-        out.push_back(row);
-    }
-    LeaveCriticalSection(&g_RingCs);
-
-    {
-        // Disambiguates XDodge's projs=0:
-        //   validSlots=0                 → nothing ever captured (detour/hook)
-        //   validSlots>0 returned=0      → captured but filtered: expired=N
-        //     (lifetime/spawnTick wrong) or future=N (clock/spawnTick skew)
-        //   returned>0 but XDodge projs=0→ mismatch between this & XDodge call
-        static int s_n = 0;
-        if ((s_n++ % 120) == 0)
-            DBG_FILE_LOG("[ProjectileTracking] CopyActiveForDraw: validSlots=" << dbgValid
-                << " returned=" << out.size()
-                << " expiredFiltered=" << dbgExpired
-                << " futureFiltered=" << dbgFuture
-                << " (call=" << s_n << ")");
-    }
+    ProjectileStore::CopyActiveForDraw(out);
 }
 
 int CountValidForDiagnostics()
 {
-    const ULONGLONG now = GetTickCount64();
-    int n = 0;
-    EnterCriticalSection(&g_RingCs);
-    for (int i = 0; i < kMaxTrackedProj; ++i) {
-        const WorldProjectile& s = g_Slots[i];
-        if (!s.valid) continue;
-        float elapsed = static_cast<float>(now - s.spawnTick);
-        if (s.lifetime > 0.f && elapsed >= s.lifetime) continue;
-        ++n;
-    }
-    LeaveCriticalSection(&g_RingCs);
-    return n;
+    return ProjectileStore::CountValidForDiagnostics();
 }
 
 void CopyActiveLocalForDraw(std::vector<WorldProjectile>& out)
 {
-    out.clear();
-    if (!g_LocalCsInit) return;
-    const ULONGLONG now = GetTickCount64();
-    EnterCriticalSection(&g_LocalCs);
-    for (int i = 0; i < kMaxLocalProj; ++i) {
-        const WorldProjectile& s = g_LocalSlots[i];
-        if (!s.valid) continue;
-        float elapsed = static_cast<float>(now - s.spawnTick);
-        if (s.lifetime <= 0.f) continue;
-        if (elapsed >= s.lifetime) continue;
-        WorldProjectile row;
-        FillOutFromSlot(row, s, now, true);
-        out.push_back(row);
-    }
-    LeaveCriticalSection(&g_LocalCs);
+    ProjectileStore::CopyActiveLocalForDraw(out);
 }
 
 void ComputePosAt(const WorldProjectile& proj, float tMs, float& outX, float& outY)
 {
-    ProjPosAt(proj, tMs, outX, outY);
+    const float fallbackX = outX;
+    const float fallbackY = outY;
+    if (!ProjectileTrajectory::GetPositionAtTime(proj, tMs, outX, outY)) {
+        outX = fallbackX;
+        outY = fallbackY;
+    }
 }
 
 void SetFlashSpeedMultiplier(float m)
@@ -1344,12 +551,12 @@ float EffectiveSpeedMulFromProjectile(void* hbeakInstance)
 
 float NormalizeProjectileLifetimeMs(float rawFromProps)
 {
-    return NormalizeLifetimeToMs(rawFromProps);
+    return ProjectileTrajectory::NormalizeLifetimeMs(rawFromProps);
 }
 
 float NormalizeAccelDelayMs(float rawFromProps)
 {
-    return NormalizeAccelDelayToMs(rawFromProps);
+    return ProjectileTrajectory::NormalizeAccelDelayMs(rawFromProps);
 }
 
 bool TryReadProjRadiusFromInstance(void* hbeakInstance, float& outRadius)
@@ -1370,32 +577,12 @@ uint32_t GetHbeakProjRadiusOffset()
 
 void RegisterHazardSpawnCallback(HazardSpawnCb cb, void* user)
 {
-    if (!g_CsInit) {
-        // Critical sections are initialised inside Install(). If the caller
-        // (e.g. DangerPlanner::TryInstall) wins the race before ProjectileTracking
-        // self-installs, do a direct assignment — the spawn detour hasn't been
-        // attached yet, so nothing else can be touching these globals.
-        g_HazardCb     = cb;
-        g_HazardCbUser = user;
-        return;
-    }
-    EnterCriticalSection(&g_RingCs);
-    g_HazardCb     = cb;
-    g_HazardCbUser = user;
-    LeaveCriticalSection(&g_RingCs);
+    ProjectileStore::RegisterHazardSpawnCallback(cb, user);
 }
 
 void ClearHazardSpawnCallback()
 {
-    if (!g_CsInit) {
-        g_HazardCb     = nullptr;
-        g_HazardCbUser = nullptr;
-        return;
-    }
-    EnterCriticalSection(&g_RingCs);
-    g_HazardCb     = nullptr;
-    g_HazardCbUser = nullptr;
-    LeaveCriticalSection(&g_RingCs);
+    ProjectileStore::ClearHazardSpawnCallback();
 }
 
 } // namespace ProjectileTracking

--- a/internal/src/features/movement/dodge/ProjectileTracking.h
+++ b/internal/src/features/movement/dodge/ProjectileTracking.h
@@ -11,6 +11,7 @@ namespace ProjectileTracking {
 
     void Install();
     void Uninstall();
+    bool IsInstalled();
 
     void SetLocalPlayerObjectId(int32_t objectId);
     int32_t GetLocalPlayerObjectId();
@@ -18,12 +19,6 @@ namespace ProjectileTracking {
     // Cleared at the start of each WorldTAB entity scan; filled per entity for shooter-origin lookup.
     void OnWorldRefreshBegin();
     void OnWorldEntity(int32_t objectId, float x, float y);
-
-    // Called from DebugTAB::Render when toggles change.
-    void SetVisualFlags(bool showPaths, bool showHitboxes);
-
-    bool ShowPaths();
-    bool ShowHitboxes();
 
     // Copy active (unexpired) shots into `out` (under lock). Used by WorldTAB::DoRefresh.
     void SnapshotToWorld(std::vector<WorldProjectile>& out);
@@ -34,13 +29,10 @@ namespace ProjectileTracking {
     // Local player projectile paths only.
     void CopyActiveLocalForDraw(std::vector<WorldProjectile>& out);
 
-    // Predicted world position at tMs after spawn (DIA4A ProjPosAt).
+    // Game-authored world position at tMs after spawn. Compatibility wrapper around HBEAKBIHANL.GIBLKPDHLBG.
     void ComputePosAt(const WorldProjectile& proj, float tMs, float& outX, float& outY);
 
-    // SEH-guarded variant. ComputePosAt occasionally touches fields on a
-    // projectile that has gone stale mid-tick. Use this from any caller
-    // that might race the despawn path (DangerMap, DangerPlanner).
-    // outX/outY are zero on guard trip.
+    // Compatibility wrapper for legacy callers. Leaves outX/outY unchanged if the game call fails.
     void ComputePosAtSafe(const WorldProjectile& proj, float tMs, float& outX, float& outY);
 
     // Optional UI scale (default 1) multiplied with native per-shot speed mult from IL2CPP field KDAJOMOFMJB.
@@ -51,9 +43,6 @@ namespace ProjectileTracking {
     // Values > 0.3001 replace KOBMINBDOBD startX/Y with cos/sin * offset; at 0.3 no extra work per shot.
     void  SetLocalPlayerMuzzleOffsetTiles(float tiles);
     float GetLocalPlayerMuzzleOffsetTiles();
-
-    // Last world (sx,sy) for a local SpawnProjectile (muzzle debug overlay).
-    bool GetMuzzleDebugLastSpawn(float& outWorldX, float& outWorldY);
 
     // HBEAKBIHANL instance: reads KDAJOMOFMJB via il2cpp_field_get_offset, × GetFlashSpeedMultiplier().
     float EffectiveSpeedMulFromProjectile(void* hbeakInstance);

--- a/internal/src/features/projectiles/ProjectileRuntimeReader.cpp
+++ b/internal/src/features/projectiles/ProjectileRuntimeReader.cpp
@@ -1,0 +1,162 @@
+#include "pch-il2cpp.h"
+
+#include "ProjectileRuntimeReader.h"
+#include "ProjectileTrajectory.h"
+#include "RuntimeOffsets.h"
+#include "gui/tabs/WorldTAB.h"
+
+#include <cmath>
+
+namespace {
+
+static bool AddrOk(const void* p)
+{
+    const uintptr_t a = reinterpret_cast<uintptr_t>(p);
+    return a > 0x10000 && a < 0x7FFFFFFFFFFFULL;
+}
+
+static void ReadCollisionHalf(WorldProjectile& dst, void* projectilePtr, uint8_t* props,
+                              ProjectileCollisionFallback fallbackMode)
+{
+    float collMult = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_CollMult);
+    if (!std::isfinite(collMult) || collMult <= 0.f || collMult > 20.f)
+        collMult = 1.0f;
+
+    const float magnitude = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Magnitude);
+    dst.magnitude = magnitude;
+
+    float baseRadius = 0.f;
+    float scale = 0.f;
+    float skinWidth = 0.f;
+    if (AddrOk(projectilePtr)) {
+        __try {
+            uint8_t* proj = reinterpret_cast<uint8_t*>(projectilePtr);
+            if (RuntimeOffsets::KJ_BaseRadius && RuntimeOffsets::KJ_BaseRadius < 0x8000)
+                baseRadius = *reinterpret_cast<float*>(proj + RuntimeOffsets::KJ_BaseRadius);
+            if (RuntimeOffsets::KJ_Scale && RuntimeOffsets::KJ_Scale < 0x8000)
+                scale = *reinterpret_cast<float*>(proj + RuntimeOffsets::KJ_Scale);
+            if (RuntimeOffsets::KJ_SkinWidthObj && RuntimeOffsets::KJ_SkinWidthObj < 0x8000)
+                skinWidth = *reinterpret_cast<float*>(proj + RuntimeOffsets::KJ_SkinWidthObj);
+        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    }
+
+    if (std::isfinite(baseRadius) && baseRadius > 0.01f && baseRadius < 4.f &&
+        std::isfinite(scale) && scale > 0.01f && scale < 20.f) {
+        dst.projHalfSize = baseRadius * scale;
+    } else if (fallbackMode == ProjectileCollisionFallback::WorldManager) {
+        const float magnitudeFallback = (magnitude > 0.f) ? magnitude * 0.10f : collMult;
+        dst.projHalfSize = (skinWidth > 0.f) ? skinWidth : magnitudeFallback;
+    } else {
+        dst.projHalfSize = collMult * 0.5f;
+    }
+}
+
+} // namespace
+
+namespace ProjectileRuntimeReader {
+
+void* EffectivePropsFromProjectile(void* projectilePtr, void* fallbackProps)
+{
+    if (AddrOk(projectilePtr)) {
+        __try {
+            void* props = *reinterpret_cast<void**>(
+                reinterpret_cast<uint8_t*>(projectilePtr) + RuntimeOffsets::Hbeak_ProjPropsPtr);
+            if (AddrOk(props)) return props;
+        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    }
+    return fallbackProps;
+}
+
+bool TryReadRuntimeChebyshevHalf(void* projectilePtr, float& outHalf)
+{
+    outHalf = 0.f;
+    if (!AddrOk(projectilePtr)) return false;
+    const uint32_t off = RuntimeOffsets::Hbeak_ProjRadius;
+    if (off == 0u || off >= 0x8000u) return false;
+    __try {
+        const float half = *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(projectilePtr) + off);
+        if (half > 1e-4f && half < 16.f && std::isfinite(half)) {
+            outHalf = half;
+            return true;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    return false;
+}
+
+bool ApplyProperties(WorldProjectile& dst, void* projectilePtr, void* projProps,
+                     ProjectileCollisionFallback collisionFallback)
+{
+    if (!AddrOk(projProps)) return false;
+    __try {
+        uint8_t* props = reinterpret_cast<uint8_t*>(projProps);
+        dst.projPropsPtr = projProps;
+        dst.lifetime = ProjectileTrajectory::NormalizeLifetimeMs(
+            *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Lifetime));
+        dst.speed = static_cast<float>(*reinterpret_cast<int32_t*>(props + RuntimeOffsets::PP_Speed));
+        dst.wavy = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsWavy);
+        dst.hasCustomAmplitude = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_HasCustomAmplitude);
+        dst.boomerang = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsBoomerang);
+        dst.parametric = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsParametric);
+        dst.frequency = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Frequency);
+        dst.amplitude = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Amplitude);
+        dst.minDamage = *reinterpret_cast<int32_t*>(props + RuntimeOffsets::PP_MinDamage);
+        dst.damage = *reinterpret_cast<int32_t*>(props + RuntimeOffsets::PP_MaxDamage);
+        dst.isAccelerating = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsAccel);
+        dst.useAccel = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_UseAccel);
+        dst.acceleration = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Acceleration);
+        dst.accelerationInv = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_AccelerationInv);
+        dst.velocityChangeRate = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_VelocityChangeRate);
+        dst.velocityChangeRateInv = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_VelocityChangeRateInv);
+        dst.accelDelay = ProjectileTrajectory::NormalizeAccelDelayMs(
+            *reinterpret_cast<float*>(props + RuntimeOffsets::PP_AccelDelay));
+        dst.speedClamp = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_SpeedClamp);
+        ReadCollisionHalf(dst, projectilePtr, props, collisionFallback);
+
+        const float laserDist = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_LaserDist);
+        dst.laserDistance = (laserDist > 1e-4f && std::isfinite(laserDist)) ? laserDist : 0.f;
+        dst.laser = dst.laserDistance > 1e-3f;
+        dst.isTurning = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsTurning);
+        dst.isCircleTurnDelayed = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsTurning + 1);
+        dst.isTurningDelayed = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsTurningDelayed);
+        dst.turnSnapsToStraight = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsTurning + 5);
+        dst.isTurningAccelerated = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsTurning + 3);
+        dst.turnRate = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_TurnRate);
+        if (!std::isfinite(dst.turnRate)) dst.turnRate = 0.f;
+
+        const float turnStopTime = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_TurnStopTime);
+        dst.turnStopTime = (std::isfinite(turnStopTime) && turnStopTime > 0.f) ? turnStopTime : 0.f;
+        dst.turnRateDelay = ProjectileTrajectory::NormalizeAccelDelayMs(
+            *reinterpret_cast<float*>(props + RuntimeOffsets::PP_TurnRateDelay));
+        const float circleTurnAngle = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_CircleTurnAngle);
+        dst.circleTurnAngle = std::isfinite(circleTurnAngle) ? circleTurnAngle : 0.f;
+        const float circleTurnDelay = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_CircleTurnDelay);
+        dst.circleTurnDelay = (std::isfinite(circleTurnDelay) && circleTurnDelay > 0.f) ? circleTurnDelay : 0.f;
+        const float turnAcceleration = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_TurnAcceleration);
+        dst.turnAcceleration = std::isfinite(turnAcceleration) ? turnAcceleration : 0.f;
+        const float turnAccelDelay = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_TurnAccelDelay);
+        dst.turnAccelDelay = std::isfinite(turnAccelDelay) ? turnAccelDelay : 0.f;
+        const float turnClamp = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_TurnClamp);
+        dst.turnClamp = std::isfinite(turnClamp) ? turnClamp : 0.f;
+        const float turnAccelInv = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_TurnAccelInv);
+        dst.turnAccelInv = std::isfinite(turnAccelInv) ? turnAccelInv : 0.f;
+
+        dst.hasCustomHitbox = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_HasCustomHitbox);
+        if (dst.hasCustomHitbox) {
+            void* customHitbox = *reinterpret_cast<void**>(props + RuntimeOffsets::PP_CustomHitbox);
+            if (AddrOk(customHitbox)) {
+                uint8_t* hitbox = reinterpret_cast<uint8_t*>(customHitbox);
+                dst.customOffsetX = *reinterpret_cast<float*>(hitbox + RuntimeOffsets::CH_OffsetX);
+                dst.customOffsetY = *reinterpret_cast<float*>(hitbox + RuntimeOffsets::CH_OffsetY);
+                const float hx = fabsf(dst.customOffsetX);
+                const float hy = fabsf(dst.customOffsetY);
+                dst.projHalfSize = (hx > hy) ? hx : hy;
+            }
+        }
+
+        TryReadRuntimeChebyshevHalf(projectilePtr, dst.runtimeChebyshevHalf);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    return false;
+}
+
+} // namespace ProjectileRuntimeReader

--- a/internal/src/features/projectiles/ProjectileRuntimeReader.h
+++ b/internal/src/features/projectiles/ProjectileRuntimeReader.h
@@ -1,0 +1,17 @@
+#pragma once
+
+struct WorldProjectile;
+
+enum class ProjectileCollisionFallback
+{
+    SpawnHook,
+    WorldManager,
+};
+
+namespace ProjectileRuntimeReader {
+
+    void* EffectivePropsFromProjectile(void* projectilePtr, void* fallbackProps);
+    bool TryReadRuntimeChebyshevHalf(void* projectilePtr, float& outHalf);
+    bool ApplyProperties(WorldProjectile& dst, void* projectilePtr, void* projProps,
+                         ProjectileCollisionFallback collisionFallback);
+}

--- a/internal/src/features/projectiles/ProjectileStore.cpp
+++ b/internal/src/features/projectiles/ProjectileStore.cpp
@@ -1,0 +1,238 @@
+#include "pch-il2cpp.h"
+
+#include "ProjectileStore.h"
+#include "ProjectileRuntimeReader.h"
+#include "ProjectileTrajectory.h"
+#include "RuntimeOffsets.h"
+#include "gui/tabs/WorldTAB.h"
+
+#include <atomic>
+
+namespace {
+
+constexpr int kMaxTrackedProj = 256;
+constexpr int kMaxLocalProj = 64;
+constexpr float kProjVisualTimeOffsetMs = 0.f;
+
+CRITICAL_SECTION g_RingCs;
+CRITICAL_SECTION g_LocalCs;
+std::atomic<uint32_t> g_WriteIdx{0};
+std::atomic<uint32_t> g_LocalWriteIdx{0};
+WorldProjectile g_Slots[kMaxTrackedProj]{};
+WorldProjectile g_LocalSlots[kMaxLocalProj]{};
+bool g_CsInit = false;
+bool g_LocalCsInit = false;
+ProjectileStore::HazardSpawnCb g_HazardCb = nullptr;
+void* g_HazardCbUser = nullptr;
+
+static bool AddrOk(const void* p)
+{
+    const uintptr_t a = reinterpret_cast<uintptr_t>(p);
+    return a > 0x10000 && a < 0x7FFFFFFFFFFFULL;
+}
+
+static bool TryReadLivePos(void* projInst, float& outX, float& outY)
+{
+    outX = 0.f;
+    outY = 0.f;
+    if (!AddrOk(projInst)) return false;
+    __try {
+        uint8_t* p = reinterpret_cast<uint8_t*>(projInst);
+        outX = *reinterpret_cast<float*>(p + RuntimeOffsets::PosX);
+        outY = *reinterpret_cast<float*>(p + RuntimeOffsets::PosY);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+}
+
+static void EnsureLocalCs()
+{
+    if (!g_LocalCsInit) {
+        InitializeCriticalSection(&g_LocalCs);
+        g_LocalCsInit = true;
+    }
+}
+
+static void FillOutFromSlot(WorldProjectile& dst, const WorldProjectile& src, ULONGLONG now, bool livePos)
+{
+    dst = src;
+    if (!src.valid) return;
+    if (AddrOk(src.ptr)) {
+        float runtimeHalf = 0.f;
+        ProjectileRuntimeReader::TryReadRuntimeChebyshevHalf(src.ptr, runtimeHalf);
+        dst.runtimeChebyshevHalf = (runtimeHalf > 1e-5f) ? runtimeHalf : src.runtimeChebyshevHalf;
+    }
+
+    const float elapsed = static_cast<float>(now - src.spawnTick);
+    if (livePos && AddrOk(src.ptr) && TryReadLivePos(src.ptr, dst.x, dst.y))
+        return;
+
+    if (elapsed >= 0.f && ProjectileTrajectory::GetPositionAtTime(
+            dst, elapsed + kProjVisualTimeOffsetMs, dst.x, dst.y))
+        return;
+
+    dst.x = src.x;
+    dst.y = src.y;
+}
+
+} // namespace
+
+namespace ProjectileStore {
+
+void Initialize()
+{
+    if (g_CsInit) return;
+    InitializeCriticalSection(&g_RingCs);
+    g_CsInit = true;
+}
+
+void Shutdown()
+{
+    if (g_LocalCsInit) {
+        DeleteCriticalSection(&g_LocalCs);
+        g_LocalCsInit = false;
+    }
+    if (g_CsInit) {
+        DeleteCriticalSection(&g_RingCs);
+        g_CsInit = false;
+    }
+    g_HazardCb = nullptr;
+    g_HazardCbUser = nullptr;
+}
+
+WorldProjectile StoreProjectile(bool enemyShot, const WorldProjectile& projectile)
+{
+    Initialize();
+    CRITICAL_SECTION* cs = &g_RingCs;
+    WorldProjectile* slots = g_Slots;
+    uint32_t maxSlots = kMaxTrackedProj;
+    std::atomic<uint32_t>* writeIdx = &g_WriteIdx;
+    if (!enemyShot) {
+        EnsureLocalCs();
+        cs = &g_LocalCs;
+        slots = g_LocalSlots;
+        maxSlots = kMaxLocalProj;
+        writeIdx = &g_LocalWriteIdx;
+    }
+
+    EnterCriticalSection(cs);
+    const uint32_t idx = writeIdx->fetch_add(1, std::memory_order_relaxed) % maxSlots;
+    slots[idx] = projectile;
+    const WorldProjectile snap = slots[idx];
+    LeaveCriticalSection(cs);
+    return snap;
+}
+
+void SnapshotToWorld(std::vector<WorldProjectile>& out)
+{
+    out.clear();
+    const ULONGLONG now = GetTickCount64();
+    Initialize();
+    EnterCriticalSection(&g_RingCs);
+    for (int i = 0; i < kMaxTrackedProj; ++i) {
+        const WorldProjectile& slot = g_Slots[i];
+        if (!slot.valid) continue;
+        const float elapsed = static_cast<float>(now - slot.spawnTick);
+        if (slot.lifetime > 0.f && elapsed >= slot.lifetime) continue;
+        WorldProjectile row;
+        FillOutFromSlot(row, slot, now, true);
+        out.push_back(row);
+    }
+    LeaveCriticalSection(&g_RingCs);
+}
+
+void CopyActiveForDraw(std::vector<WorldProjectile>& out)
+{
+    out.clear();
+    const ULONGLONG now = GetTickCount64();
+    Initialize();
+    EnterCriticalSection(&g_RingCs);
+    for (int i = 0; i < kMaxTrackedProj; ++i) {
+        const WorldProjectile& slot = g_Slots[i];
+        if (!slot.valid) continue;
+        const float elapsedViz = static_cast<float>(now - slot.spawnTick) + kProjVisualTimeOffsetMs;
+        if (elapsedViz < 0.f) continue;
+        if (slot.lifetime > 0.f && elapsedViz >= slot.lifetime) continue;
+        WorldProjectile row;
+        FillOutFromSlot(row, slot, now, true);
+        out.push_back(row);
+    }
+    LeaveCriticalSection(&g_RingCs);
+}
+
+void CopyActiveLocalForDraw(std::vector<WorldProjectile>& out)
+{
+    out.clear();
+    if (!g_LocalCsInit) return;
+    const ULONGLONG now = GetTickCount64();
+    EnterCriticalSection(&g_LocalCs);
+    for (int i = 0; i < kMaxLocalProj; ++i) {
+        const WorldProjectile& slot = g_LocalSlots[i];
+        if (!slot.valid) continue;
+        const float elapsed = static_cast<float>(now - slot.spawnTick);
+        if (slot.lifetime <= 0.f || elapsed >= slot.lifetime) continue;
+        WorldProjectile row;
+        FillOutFromSlot(row, slot, now, true);
+        out.push_back(row);
+    }
+    LeaveCriticalSection(&g_LocalCs);
+}
+
+int CountValidForDiagnostics()
+{
+    const ULONGLONG now = GetTickCount64();
+    int count = 0;
+    Initialize();
+    EnterCriticalSection(&g_RingCs);
+    for (int i = 0; i < kMaxTrackedProj; ++i) {
+        const WorldProjectile& slot = g_Slots[i];
+        if (!slot.valid) continue;
+        const float elapsed = static_cast<float>(now - slot.spawnTick);
+        if (slot.lifetime > 0.f && elapsed >= slot.lifetime) continue;
+        ++count;
+    }
+    LeaveCriticalSection(&g_RingCs);
+    return count;
+}
+
+void RegisterHazardSpawnCallback(HazardSpawnCb cb, void* user)
+{
+    Initialize();
+    EnterCriticalSection(&g_RingCs);
+    g_HazardCb = cb;
+    g_HazardCbUser = user;
+    LeaveCriticalSection(&g_RingCs);
+}
+
+void ClearHazardSpawnCallback()
+{
+    if (!g_CsInit) {
+        g_HazardCb = nullptr;
+        g_HazardCbUser = nullptr;
+        return;
+    }
+    EnterCriticalSection(&g_RingCs);
+    g_HazardCb = nullptr;
+    g_HazardCbUser = nullptr;
+    LeaveCriticalSection(&g_RingCs);
+}
+
+void NotifyHazardSpawn(const WorldProjectile& projectile)
+{
+    HazardSpawnCb cb = nullptr;
+    void* user = nullptr;
+    if (g_CsInit) {
+        EnterCriticalSection(&g_RingCs);
+        cb = g_HazardCb;
+        user = g_HazardCbUser;
+        LeaveCriticalSection(&g_RingCs);
+    }
+    if (cb) {
+        __try {
+            cb(projectile, user);
+        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    }
+}
+
+} // namespace ProjectileStore

--- a/internal/src/features/projectiles/ProjectileStore.h
+++ b/internal/src/features/projectiles/ProjectileStore.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+struct WorldProjectile;
+
+namespace ProjectileStore {
+
+    using HazardSpawnCb = void (*)(const WorldProjectile& proj, void* user);
+
+    void Initialize();
+    void Shutdown();
+
+    WorldProjectile StoreProjectile(bool enemyShot, const WorldProjectile& projectile);
+
+    void SnapshotToWorld(std::vector<WorldProjectile>& out);
+    void CopyActiveForDraw(std::vector<WorldProjectile>& out);
+    void CopyActiveLocalForDraw(std::vector<WorldProjectile>& out);
+    int CountValidForDiagnostics();
+
+    void RegisterHazardSpawnCallback(HazardSpawnCb cb, void* user);
+    void ClearHazardSpawnCallback();
+    void NotifyHazardSpawn(const WorldProjectile& projectile);
+}

--- a/internal/src/features/projectiles/ProjectileTrajectory.cpp
+++ b/internal/src/features/projectiles/ProjectileTrajectory.cpp
@@ -1,0 +1,146 @@
+#include "pch-il2cpp.h"
+
+#include "ProjectileTrajectory.h"
+#include "gui/tabs/WorldTAB.h"
+#include "Il2CppResolver.h"
+#include "BeebyteName.h"
+
+#include <cmath>
+
+namespace {
+
+// ── Runtime-resolved positionAt (GIBLKPDHLBG on HBEAKBIHANL) ─────────────────
+// app::HBEAKBIHANL_GIBLKPDHLBG is null in the current build (stub never set by
+// IL2CPP init). The vtable struct field is unsafe to use directly because the
+// generated offsets may not match the runtime layout. Instead, find the method
+// once via IL2CPP metadata — same pattern as ResolveProjClass() in
+// ProjectileTracking.cpp — and cache the native pointer.
+using PositionAtFn = app::Vector2(__fastcall*)(app::HBEAKBIHANL*, float, float*, float*, MethodInfo*);
+
+struct PosAtMethod {
+    PositionAtFn      fn    = nullptr;
+    const MethodInfo* mi    = nullptr;
+    bool              ok    = false;
+    bool              tried = false;
+};
+static PosAtMethod s_posAt;
+
+static const PosAtMethod& GetPosAtMethod()
+{
+    if (s_posAt.tried) return s_posAt;
+    s_posAt.tried = true;
+
+    if (app::HBEAKBIHANL_GIBLKPDHLBG) {
+        s_posAt.fn = app::HBEAKBIHANL_GIBLKPDHLBG;
+        s_posAt.ok = true;
+        return s_posAt;
+    }
+
+    Il2CppClass* klass = nullptr;
+    for (const auto& kv : Beebyte::GetMap()) {
+        if (kv.second == "Projectile") {
+            klass = Resolver::GetClass("", kv.first.c_str());
+            if (!klass) klass = Resolver::FindClassLoose(kv.first.c_str());
+            if (klass) break;
+        }
+    }
+    if (!klass) klass = Resolver::GetClass("", "HBEAKBIHANL");
+    if (!klass) klass = Resolver::FindClassLoose("HBEAKBIHANL");
+    if (!klass) return s_posAt;
+
+    void* iter = nullptr;
+    while (const MethodInfo* mi = il2cpp_class_get_methods(klass, &iter)) {
+        const char* name = il2cpp_method_get_name(mi);
+        if (!name || strcmp(name, "GIBLKPDHLBG") != 0) continue;
+        if (il2cpp_method_get_param_count(mi) != 3) continue;
+        if (!mi->methodPointer) continue;
+        s_posAt.fn = reinterpret_cast<PositionAtFn>(mi->methodPointer);
+        s_posAt.mi = mi;
+        s_posAt.ok = true;
+        break;
+    }
+    return s_posAt;
+}
+
+static bool IsFiniteWorldPoint(float x, float y)
+{
+    return std::isfinite(x) && std::isfinite(y) && fabsf(x) < 10000.f && fabsf(y) < 10000.f;
+}
+
+static bool AddrOk(const void* p)
+{
+    const uintptr_t a = reinterpret_cast<uintptr_t>(p);
+    return a > 0x10000 && a < 0x7FFFFFFFFFFFULL;
+}
+
+static bool ReadGamePositionAtTime(void* projectilePtr, float tMs, float& outX, float& outY)
+{
+    if (!AddrOk(projectilePtr)) return false;
+    const PosAtMethod& m = GetPosAtMethod();
+    if (!m.ok || !m.fn) return false;
+    bool ok = false;
+    __try {
+        float dx = 0.f, dy = 0.f;
+        auto* projectile = reinterpret_cast<app::HBEAKBIHANL*>(projectilePtr);
+        const app::Vector2 pos = m.fn(projectile, tMs, &dx, &dy,
+                                      const_cast<MethodInfo*>(m.mi));
+        if (IsFiniteWorldPoint(pos.x, pos.y)) {
+            outX = pos.x;
+            outY = pos.y;
+            ok = true;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        ok = false;
+    }
+    return ok;
+}
+
+} // namespace
+
+namespace ProjectileTrajectory {
+
+float NormalizeLifetimeMs(float rawFromProps)
+{
+    if (!(rawFromProps > 0.f) || rawFromProps != rawFromProps)
+        return 2000.f;
+    if (rawFromProps < 250.f)
+        return rawFromProps * 1000.f;
+    return rawFromProps;
+}
+
+float NormalizeAccelDelayMs(float rawFromProps)
+{
+    if (!(rawFromProps > 0.f) || rawFromProps != rawFromProps)
+        return 0.f;
+    if (rawFromProps < 250.f)
+        return rawFromProps * 1000.f;
+    return rawFromProps;
+}
+
+bool GetPositionAtTime(const WorldProjectile& proj, float tMs, float& outX, float& outY)
+{
+    outX = 0.f;
+    outY = 0.f;
+    return ReadGamePositionAtTime(proj.ptr, tMs, outX, outY);
+}
+
+bool CachePath(WorldProjectile& proj)
+{
+    proj.hasCachedPath = false;
+    proj.pathSampleCount = 0;
+    const float lifetime = (proj.lifetime > 1.f && std::isfinite(proj.lifetime)) ? proj.lifetime : 2000.f;
+    constexpr int sampleCap = kWorldProjectilePathSampleCap;
+    for (int i = 0; i < sampleCap; ++i) {
+        const float tMs = (lifetime * static_cast<float>(i)) / static_cast<float>(sampleCap - 1);
+        float x = 0.f, y = 0.f;
+        if (!GetPositionAtTime(proj, tMs, x, y)) break;
+        proj.pathSampleTimesMs[proj.pathSampleCount] = tMs;
+        proj.pathX[proj.pathSampleCount] = x;
+        proj.pathY[proj.pathSampleCount] = y;
+        ++proj.pathSampleCount;
+    }
+    proj.hasCachedPath = proj.pathSampleCount >= 2;
+    return proj.hasCachedPath;
+}
+
+} // namespace ProjectileTrajectory

--- a/internal/src/features/projectiles/ProjectileTrajectory.h
+++ b/internal/src/features/projectiles/ProjectileTrajectory.h
@@ -1,0 +1,13 @@
+#pragma once
+
+struct WorldProjectile;
+
+namespace ProjectileTrajectory {
+
+    float NormalizeLifetimeMs(float rawFromProps);
+    float NormalizeAccelDelayMs(float rawFromProps);
+
+    bool GetPositionAtTime(const WorldProjectile& proj, float tMs, float& outX, float& outY);
+
+    bool CachePath(WorldProjectile& proj);
+}

--- a/internal/src/gui/tabs/WorldTAB.cpp
+++ b/internal/src/gui/tabs/WorldTAB.cpp
@@ -1,0 +1,2369 @@
+#include "pch-il2cpp.h"
+
+#define IMGUI_DEFINE_MATH_OPERATORS
+
+#include "gui/tabs/WorldTAB.h"
+#include "AoeTracking.h"
+#include "ProjectileTracking.h"
+#include "features/projectiles/ProjectileRuntimeReader.h"
+#include "features/projectiles/ProjectileTrajectory.h"
+#include "Il2CppResolver.h"
+#include "RuntimeOffsets.h"
+#include "GameState.h"
+#include "LocalPlayer.h"
+#include "helpers.h"
+#include "BeebyteName.h"
+#include <imgui/imgui.h>
+#include <imgui/imgui_internal.h>
+#include <vector>
+#include <algorithm>
+#include <cstdint>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <windows.h>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runtime-confirmed field offsets.
+// KJMONHENJEN (base class) fields have NO ACTK shift — confirmed by X/Y at 0x3C/0x40.
+//   objectType = HFDNHJFNEKA @ 0x30  (no shift, confirmed by probe: player=782 at 0x30)
+//   pos X/Y    = CLFEOFKBNEJ/PKEECFNFEIO @ 0x3C / 0x40
+// LKHPPBEGNOM ACTK anti-tamper inserts hidden fields:
+//   +0x50 before dump-0x1B8 → hp/maxHp at runtime 0x208/0x20C
+// WorldManager itself has NO shift.
+// ─────────────────────────────────────────────────────────────────────────────
+// Game-specific field offsets — resolved at runtime by RuntimeOffsets::EnsureAll().
+// These aliases let the rest of this file stay unchanged.
+static const uint32_t& OFF_POS_X           = RuntimeOffsets::PosX;
+static const uint32_t& OFF_POS_Y           = RuntimeOffsets::PosY;
+static const uint32_t& OFF_HP              = RuntimeOffsets::HP;
+static const uint32_t& OFF_MAX_HP          = RuntimeOffsets::MaxHP;
+
+// WorldManager (HJMBOMEHGDJ)
+static const uint32_t& OFF_WM_ALL_DICT      = RuntimeOffsets::WM_AllDict;
+static const uint32_t& OFF_WM_MAPOBJ_DICT_A = RuntimeOffsets::WM_MapDictA;
+static const uint32_t& OFF_WM_MAPOBJ_DICT_B = RuntimeOffsets::WM_MapDictB;
+static const uint32_t& OFF_WM_KJMON_LIST    = RuntimeOffsets::WM_KjmonList;
+// NOTE: raw ints at tile 0x70/0x74 are NOT minDmg/maxDmg — 0x74 is a tick counter.
+// BGAIOPJMHLO tile instance fields:
+static const uint32_t& OFF_WM_TILE_ARR     = RuntimeOffsets::WM_TileArr;
+static const uint32_t& OFF_WM_TILE_LIST    = RuntimeOffsets::WM_TileList;
+static const uint32_t& OFF_TILE_X          = RuntimeOffsets::TileX;
+static const uint32_t& OFF_TILE_Y          = RuntimeOffsets::TileY;
+static const uint32_t& OFF_TILE_TYPE       = RuntimeOffsets::TileType;
+static const uint32_t& OFF_TILE_PROPS      = RuntimeOffsets::TileProps;
+// CMFPKCJHKKB (XmlTileProperties) string fields — non-null means condition present:
+static const uint32_t& OFF_TP_SPEED        = RuntimeOffsets::TP_Speed;
+static const uint32_t& OFF_TP_SINK         = RuntimeOffsets::TP_Sink;
+static const uint32_t& OFF_TP_NOWALK       = RuntimeOffsets::TP_NoWalk;
+static const uint32_t& OFF_TP_MINDMG       = RuntimeOffsets::TP_MinDmg;
+static const uint32_t& OFF_TP_MAXDMG       = RuntimeOffsets::TP_MaxDmg;
+static const uint32_t& OFF_TP_PUSH         = RuntimeOffsets::TP_Push;
+static const uint32_t& OFF_TP_ALPHA        = RuntimeOffsets::TP_Alpha;
+static const uint32_t& OFF_TP_SINKING      = RuntimeOffsets::TP_Sinking;
+// IL2CPP System.String layout: +0x10 = int32 length, +0x14 = UTF-16LE chars[]
+static constexpr uint32_t OFF_STR_LEN       = 0x10;
+static constexpr uint32_t OFF_STR_CHARS     = 0x14;
+// Tile/object condition flags defined in WorldTAB.h (TCOND_*, OCOND_*)
+static constexpr uint32_t OFF_LIST_ITEMS    = 0x10;   // IL2CPP List<T>._items
+static constexpr uint32_t OFF_LIST_SIZE     = 0x18;   // IL2CPP List<T>._size
+static constexpr uint32_t MAX_TILES         = 65536;
+static const uint32_t& OFF_WM_LOCAL         = RuntimeOffsets::WM_Local;
+
+// FKALGHJIADI / LKHPPBEGNOM player name fields — confirmed by runtime blind scan:
+// IGN (DPGEBOCBKEF @ LKHPPBEGNOM dump 0x178) is at runtime 0x178 — NO ACTK shift (below insertion point)
+// Guild name (NFJGJKLPLBA @ FKALGHJIADI dump 0x468) is at runtime 0x468 — dump offsets for FKALGHJIADI
+// own fields ARE the runtime offsets (the dump was generated from the already-patched binary).
+static const uint32_t& OFF_PLAYER_IGN       = RuntimeOffsets::PlayerIGN;
+static constexpr uint32_t OFF_PLAYER_GUILD  = 0x468;  // string NFJGJKLPLBA — guild name (empty if no guild)
+// KJMONHENJEN.FDNHINDAEHK — dict key / object id when pointer match fails vs GameState::GetLocalPtr()
+static constexpr uint32_t OFF_KJM_OBJECT_ID = 0xC0;
+
+// ObjectProperties (XML data) on every entity — no ACTK shift (KJMONHENJEN base fields are unshifted)
+// OFF_OP_* = byte offset from ObjectProperties* (klass 8 + monitor 8 + fields…).
+// Old 0x6C1+ region sits inside String* / padding — not bools; bool cluster follows il2cpp-types.h:
+// isEventChestBoss(0x698), isKey(0x699), occupySquare(0x69A),
+// then int32 type @0x69C; after displayId/displayIdWithQty pointers, isEnemy @0x6C9; fullOccupy @0x6D1,
+// enemyOccupySquare @0x6D2, isStatic @0x6D3, blockProjectiles @0x6D4; protect* @0x6DC/0x6DD; flying @0x6E4
+static const uint32_t& OFF_KJM_OBJPROPS     = RuntimeOffsets::ObjProps;
+static const uint32_t& OFF_OP_ID_STR        = RuntimeOffsets::OP_IdStr;
+static const uint32_t& OFF_OP_NOCOVER       = RuntimeOffsets::OP_NoCover;
+static const uint32_t& OFF_OP_NOWALL_RPT    = RuntimeOffsets::OP_NoWallRpt;
+static const uint32_t& OFF_OP_OCCUPY_SQ     = RuntimeOffsets::OP_OccupySq;
+static const uint32_t& OFF_OP_FULL_OCC      = RuntimeOffsets::OP_FullOcc;
+static const uint32_t& OFF_OP_ENEMY_OCC     = RuntimeOffsets::OP_EnemyOcc;
+static const uint32_t& OFF_OP_IS_ENEMY      = RuntimeOffsets::OP_IsEnemy;
+static const uint32_t& OFF_OP_IS_STATIC     = RuntimeOffsets::OP_IsStatic;
+static const uint32_t& OFF_OP_BLOCK_PROJ    = RuntimeOffsets::OP_BlockProj;
+static const uint32_t& OFF_OP_PROT_GND      = RuntimeOffsets::OP_ProtGnd;
+static const uint32_t& OFF_OP_PROT_SINK     = RuntimeOffsets::OP_ProtSink;
+static const uint32_t& OFF_OP_FLYING        = RuntimeOffsets::OP_Flying;
+static const uint32_t& OFF_OP_CONNECT_T     = RuntimeOffsets::OP_ConnectT;
+// Object condition bitmask flags — defined in WorldTAB.h
+
+// WorldManager time/tick display fields
+static constexpr uint32_t OFF_WM_UINT_D8    = 0xD8;
+static constexpr uint32_t OFF_WM_UINT_DC    = 0xDC;
+static constexpr uint32_t OFF_WM_UINT_E0    = 0xE0;
+static constexpr uint32_t OFF_WM_FLOAT_F4   = 0xF4;
+static constexpr uint32_t OFF_WM_FLOAT_F8   = 0xF8;
+static constexpr uint32_t OFF_WM_INT_FC     = 0xFC;
+static constexpr uint32_t OFF_WM_INT_100    = 0x100;
+
+// IL2CPP Dictionary<int, ptr> layout
+static constexpr uint32_t OFF_DICT_ENTRIES  = 0x18;
+static constexpr uint32_t OFF_DICT_COUNT    = 0x20;
+
+// IL2CPP Array layout
+static constexpr uint32_t OFF_ARR_MAXLEN    = 0x18;
+static constexpr uint32_t OFF_ARR_DATA      = 0x20;
+
+// Dictionary Entry layout (24 bytes: hash+next+key+pad+value*)
+static constexpr uint32_t DICT_ENTRY_SIZE   = 24;
+static constexpr uint32_t OFF_ENTRY_HASH    = 0;
+static constexpr uint32_t OFF_ENTRY_KEY     = 8;
+static constexpr uint32_t OFF_ENTRY_VALUE   = 16;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entity classification
+// ─────────────────────────────────────────────────────────────────────────────
+// Players — FKALGHJIADI only (sealed local/other player class in dump)
+// Enemies — PMMFLLAIPGN (characters that are not FKALGHJIADI)
+// Objects — portals, chests, statics (everything else in the dict)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum class EntityCat : int { All = 0, Player = 1, Enemy = 2, Object = 3 };
+static const char* kCatLabels[] = { "All", "Players", "Enemies", "Objects" };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data structures (WorldEntity defined in WorldTAB.h for cross-tab access)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// WorldTile defined in WorldTAB.h for cross-tab access
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module-level state
+// ─────────────────────────────────────────────────────────────────────────────
+static std::vector<WorldEntity>     g_entities;
+static std::vector<WorldTile>       g_tiles;
+static std::vector<WorldProjectile>  g_projectiles;
+
+// Movement tile maps — rebuilt once per DoRefresh(), O(1) lookup per frame.
+// Key: (uint16_t(tx) << 16) | uint16_t(ty).
+static std::unordered_map<uint32_t, bool>  s_blockedMap;    // present = movement blocked (NoWalk / OccupySquare / FullOccupy)
+static std::unordered_map<uint32_t, bool>  s_fullOccupyMap; // present = tile has FullOccupy entity (for sub-tile neighbour check)
+static std::unordered_map<uint32_t, bool>  s_damagingMap;  // present = tile deals damage (minDmg/maxDmg > 0)
+static std::unordered_map<uint32_t, float> s_tileSpeedMap; // value = XML speed multiplier (non-zero tiles only)
+static std::mutex s_tileMapMutex;
+
+static inline uint32_t BlockedKey(int tx, int ty)
+{
+    return (static_cast<uint32_t>(static_cast<uint16_t>(tx)) << 16) |
+            static_cast<uint32_t>(static_cast<uint16_t>(ty));
+}
+
+static void RebuildBlockedMap()
+{
+    std::unordered_map<uint32_t, bool> blockedMap;
+    std::unordered_map<uint32_t, bool> fullOccupyMap;
+    std::unordered_map<uint32_t, bool> damagingMap;
+    std::unordered_map<uint32_t, float> tileSpeedMap;
+
+    blockedMap.reserve(g_tiles.size() + g_entities.size());
+    fullOccupyMap.reserve(g_entities.size());
+    damagingMap.reserve(g_tiles.size());
+    tileSpeedMap.reserve(g_tiles.size());
+
+    for (const WorldTile& t : g_tiles) {
+        uint32_t k = BlockedKey(t.tileX, t.tileY);
+        // Only truly impassable tiles go in the blocked map — damage tiles are
+        // physically walkable (the game triggers damage from player centre, not hitbox).
+        if (t.conds & TCOND_NOWALK)
+            blockedMap[k] = true;
+        // Damaging tiles tracked separately: damage triggers when the player centre
+        // (floor of world XY) lands on the tile, not when the hitbox overlaps it.
+        if (t.minDmg > 0 || t.maxDmg > 0)
+            damagingMap[k] = true;
+        // Store speed modifier for any tile that has one (0 = no modifier)
+        if (t.speed != 0.f)
+            tileSpeedMap[k] = t.speed;
+    }
+
+    // Flash isWalkable() parity: a tile is blocked (cannot be entered from outside)
+    // if its object has OccupySquare, FullOccupy, or EnemyOccupySquare.
+    // EnemyOccupySquare is what breakable walls / pillars / destructibles use —
+    // they're Enemy-class (have HP, can be attacked) AND block movement.
+    // Without ENEMY_OCC in this criteria, A* happily plans through them and
+    // the player walks into a tile the game refuses to enter → snap-back.
+    // FullOccupy is additionally tracked separately for the sub-tile neighbour
+    // check (isValidPosition section B: fractional-position constraints on
+    // adjacent tiles).
+    for (const WorldEntity& e : g_entities) {
+        if (e.objConds & (OCOND_OCCUPY_SQ | OCOND_FULL_OCC | OCOND_ENEMY_OCC)) {
+            int tx = static_cast<int>(floorf(e.x));
+            int ty = static_cast<int>(floorf(e.y));
+            blockedMap[BlockedKey(tx, ty)] = true;
+        }
+        if (e.objConds & OCOND_FULL_OCC) {
+            int tx = static_cast<int>(floorf(e.x));
+            int ty = static_cast<int>(floorf(e.y));
+            fullOccupyMap[BlockedKey(tx, ty)] = true;
+        }
+    }
+
+    std::lock_guard<std::mutex> lock(s_tileMapMutex);
+    s_blockedMap.swap(blockedMap);
+    s_fullOccupyMap.swap(fullOccupyMap);
+    s_damagingMap.swap(damagingMap);
+    s_tileSpeedMap.swap(tileSpeedMap);
+}
+
+static std::string  g_status       = "Press Refresh while in-game.";
+static bool         g_statusOk     = true;
+static float        g_localX       = 0.f;
+static float        g_localY       = 0.f;
+static bool         g_autoRefresh  = false;
+static float        g_autoTimer    = 0.f;
+static float        g_autoInterval = 1.0f;
+
+// Filter / view state
+static char         g_filter[64]   = {};
+static char         g_tileFilter[64] = {};
+static EntityCat    g_entityCat    = EntityCat::All;
+static int          g_activeTable  = 0;   // 0 = entities, 1 = tiles, 2 = projectiles, 3 = throwables/AOEs
+static char         g_projFilter[96]   = {};
+
+// Managed object inspect popup (double-click Ptr in entity / projectile tables)
+static Il2CppObject* s_worldInspectObj       = nullptr;
+static int32_t       s_worldInspectObjectId  = 0;
+static char          s_worldInspectSubtitle[192] = {};
+// ImGui popup IDs are stack-relative; OpenPopup inside a table row must use the same
+// ImGuiID as BeginPopup at window root (see imgui.cpp OpenPopup comment).
+static ImGuiID       s_worldInspectPopupRootId = 0;
+static char          s_worldInspectSearchBuf[256] = {};
+
+// String edit buffers for inspect modal (cleared when popup opens).
+static std::unordered_map<uint64_t, std::vector<char>> s_worldInspectStrFieldBufs;
+static std::unordered_map<uint64_t, std::vector<char>> s_worldInspectStrPropBufs;
+
+static uint64_t WorldInspectStrFieldKey(Il2CppObject* obj, FieldInfo* f, bool isStatic)
+{
+    const uintptr_t ob = isStatic ? 0u : reinterpret_cast<uintptr_t>(obj);
+    return (static_cast<uint64_t>(ob) * 0x9E3779B97F4A7C15ULL)
+         ^ static_cast<uint64_t>(reinterpret_cast<uintptr_t>(f));
+}
+
+static uint64_t WorldInspectStrPropKey(Il2CppObject* obj, const PropertyInfo* p)
+{
+    return (static_cast<uint64_t>(reinterpret_cast<uintptr_t>(obj)) * 0x9E3779B97F4A7C15ULL)
+         ^ static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p));
+}
+
+static int WorldInspectInputTextResizeCallback(ImGuiInputTextCallbackData* data)
+{
+    if (data->EventFlag == ImGuiInputTextFlags_CallbackResize) {
+        auto* vec = static_cast<std::vector<char>*>(data->UserData);
+        IM_ASSERT(data->Buf == vec->data());
+        vec->resize(static_cast<size_t>(data->BufSize));
+        data->Buf = vec->data();
+    }
+    return 0;
+}
+
+// Cached local player pointer (mirrors GameState; updated in DoRefresh/GetLocalPtr)
+static void* g_localPtr = nullptr;
+
+// WorldManager diagnostics (display only — read from GameState)
+static uintptr_t g_worldMgrPtr = 0;
+static uintptr_t g_appMgrPtr   = 0;
+static uint32_t   g_wm_d8 = 0, g_wm_dc = 0, g_wm_e0 = 0;
+static float      g_wm_f4 = 0.f, g_wm_f8 = 0.f;
+static int32_t    g_wm_fc = 0, g_wm_100 = 0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+static Il2CppClass* FindClassByName(const char* name)
+{
+    struct Ctx { const char* name; Il2CppClass* result; };
+    Ctx ctx{ name, nullptr };
+    il2cpp_class_for_each([](Il2CppClass* klass, void* ud) {
+        auto* c = static_cast<Ctx*>(ud);
+        if (c->result) return;
+        if (strcmp(il2cpp_class_get_name(klass), c->name) == 0)
+            c->result = klass;
+    }, &ctx);
+    return ctx.result;
+}
+
+template<typename T>
+static bool SafeRead(const void* base, uint32_t offset, T& out)
+{
+    return Resolver::Protection::safe_call([&]() {
+        out = *reinterpret_cast<const T*>(
+            reinterpret_cast<const uint8_t*>(base) + offset);
+    });
+}
+
+static float Distance(float ax, float ay, float bx, float by)
+{
+    float dx = ax - bx, dy = ay - by;
+    return sqrtf(dx * dx + dy * dy);
+}
+
+static bool AddrValid(const void* p)
+{
+    uintptr_t v = reinterpret_cast<uintptr_t>(p);
+    return v > 0x10000 && v < 0x7FFFFFFFFFFull;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Walk IL2CPP Dictionary<int, ptr> (same layout as entity dict @ WM+0xB0)
+// ─────────────────────────────────────────────────────────────────────────────
+template<typename Cb>
+static void WalkDict(void* dictPtr, int maxEntries, Cb cb)
+{
+    if (!AddrValid(dictPtr)) return;
+
+    void*   entriesArr = nullptr;
+    int32_t count      = 0;
+    SafeRead(dictPtr, OFF_DICT_ENTRIES, entriesArr);
+    SafeRead(dictPtr, OFF_DICT_COUNT,   count);
+    if (!AddrValid(entriesArr)) return;
+
+    int32_t maxLen = 0;
+    SafeRead(entriesArr, OFF_ARR_MAXLEN, maxLen);
+    if (maxLen <= 0 || maxLen > 65536) maxLen = maxEntries;
+    if (count  <= 0 || count  > maxLen) count = maxLen;
+
+    for (int32_t i = 0; i < count; ++i) {
+        const uint8_t* entry = reinterpret_cast<const uint8_t*>(entriesArr)
+                             + OFF_ARR_DATA
+                             + static_cast<size_t>(i) * DICT_ENTRY_SIZE;
+        int32_t hashCode = 0;
+        if (!SafeRead(entry, OFF_ENTRY_HASH, hashCode)) continue;
+        if (hashCode < 0) continue;
+
+        int32_t key   = 0;
+        void*   value = nullptr;
+        if (!SafeRead(entry, OFF_ENTRY_KEY,   key))   continue;
+        if (!SafeRead(entry, OFF_ENTRY_VALUE, value)) continue;
+        if (!AddrValid(value))                         continue;
+
+        cb(key, value);
+    }
+}
+
+// HBEAKBIHANL (runtime projectile) — klass cached here; FOMOIBCKIFP offset via RuntimeOffsets.
+static Il2CppClass* s_hbeakKlass = nullptr;
+
+static Il2CppClass* GetHbeakProjectileClass()
+{
+    if (!s_hbeakKlass)
+        s_hbeakKlass = FindClassByName("HBEAKBIHANL");
+    return s_hbeakKlass;
+}
+
+// MSVC C2712: __try cannot be used in the same function as parameters like std::vector& / std::unordered_set&.
+static float SehReadProjectileAngle148(void* elem)
+{
+    float a = 0.f;
+    __try {
+        a = *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(elem) + RuntimeOffsets::Hbeak_Angle);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    return a;
+}
+
+// If `elem` is HBEAKBIHANL (or subclass), append to `out`. DIA4A: HBEAKBIHANL : KJMONHENJEN.
+static void TryAppendHbeakFromElem(
+    void*        elem,
+    Il2CppClass* hbeakKlass,
+    uint32_t     offProjPropsField,
+    std::vector<WorldProjectile>&     out,
+    std::unordered_set<uintptr_t>&    seenPtrs)
+{
+    if (!AddrValid(elem) || !hbeakKlass) return;
+
+    void* klassRaw = nullptr;
+    if (!SafeRead(elem, 0u, klassRaw) || !AddrValid(klassRaw)) return;
+    auto* elemKlass = reinterpret_cast<Il2CppClass*>(klassRaw);
+    if (!il2cpp_class_is_assignable_from(hbeakKlass, elemKlass)) return;
+
+    const uintptr_t pu = reinterpret_cast<uintptr_t>(elem);
+    if (seenPtrs.count(pu)) return;
+    seenPtrs.insert(pu);
+
+    const ULONGLONG nowTick = GetTickCount64();
+    WorldProjectile wp{};
+    wp.ptr = elem;
+    wp.valid = true;
+    wp.spawnTick = nowTick;
+    wp.lifetime = 120000.f;
+    wp.speed = 5000.f;
+    wp.damage = 0;
+    wp.bulletId = 0;
+    SafeRead(elem, OFF_POS_X, wp.x);
+    SafeRead(elem, OFF_POS_Y, wp.y);
+    wp.angle = SehReadProjectileAngle148(elem);
+
+    void* projProps = nullptr;
+    if (SafeRead(elem, offProjPropsField, projProps) && AddrValid(projProps)) {
+        ProjectileRuntimeReader::ApplyProperties(
+            wp, elem, projProps, ProjectileCollisionFallback::WorldManager);
+        if (wp.lifetime < 50.f || wp.lifetime > 600000.f)
+            wp.lifetime = 120000.f;
+        wp.speedMul = ProjectileTracking::EffectiveSpeedMulFromProjectile(elem);
+    }
+
+    // Approximate spawn from HBEAKBIHANL.GLEGBLDBOJF @ 0x16C (types.cs) as elapsed ms.
+    // This is the only reliable way to set spawnTick for projectiles discovered from
+    // WorldManager containers (non-spawn-hook path). Without it:
+    //   - elapsed = now - spawnTick ≈ 0 → projectiles never expire ("go on forever")
+    //   - path anchoring fails because live position doesn't align with t=0
+    static constexpr uint32_t OFF_HBEAK_GLEGBLDBOJF = 0x16C;
+    int32_t                   ageMs               = -1;
+    SafeRead(elem, OFF_HBEAK_GLEGBLDBOJF, ageMs);
+    if (ageMs >= 0 && static_cast<float>(ageMs) < wp.lifetime * 1.05f && static_cast<float>(ageMs) < 120000.f)
+        wp.spawnTick = nowTick - static_cast<uint64_t>(ageMs);
+
+    // Lasers are stationary: live XY == spawn origin, so back-calculating startX
+    // via speed×age would produce a position one beam-length behind the emitter.
+    const bool straight = !wp.wavy && !wp.parametric && !wp.laser && (fabsf(wp.amplitude) < 1e-4f);
+    if (straight && ageMs >= 0 && wp.speed > 1.f) {
+        float dist   = (wp.speed / 10000.f) * static_cast<float>(ageMs);
+        float ca     = cosf(wp.angle);
+        float sa     = sinf(wp.angle);
+        wp.startX    = wp.x - dist * ca;
+        wp.startY    = wp.y - dist * sa;
+    } else {
+        wp.startX = wp.x;
+        wp.startY = wp.y;
+    }
+
+    ProjectileTrajectory::CachePath(wp);
+
+    out.push_back(wp);
+}
+
+// WM+0xB8 / +0xC0: Dictionary<int, KJMONHENJEN> (DIA4A KHIHFNACEKJ, CIOIHEOEAEB)
+static void TryMergeProjectileDict(
+    void*        dictPtr,
+    Il2CppClass* hbeakKlass,
+    uint32_t     offProjPropsField,
+    std::vector<WorldProjectile>&  out,
+    std::unordered_set<uintptr_t>&   seenPtrs)
+{
+    if (!AddrValid(dictPtr) || !hbeakKlass) return;
+    WalkDict(dictPtr, 8192, [&](int32_t /*key*/, void* value) {
+        TryAppendHbeakFromElem(value, hbeakKlass, offProjPropsField, out, seenPtrs);
+    });
+}
+
+// WM+0xE8: List<KJMONHENJEN> ONABHKFOJNE
+static void TryMergeKjmonProjectileList(
+    void*        listObj,
+    Il2CppClass* hbeakKlass,
+    uint32_t     offProjPropsField,
+    std::vector<WorldProjectile>&  out,
+    std::unordered_set<uintptr_t>&   seenPtrs)
+{
+    if (!AddrValid(listObj) || !hbeakKlass) return;
+
+    int32_t listSize = 0;
+    void*   itemsArr = nullptr;
+    if (!SafeRead(listObj, OFF_LIST_SIZE, listSize)) return;
+    if (!SafeRead(listObj, OFF_LIST_ITEMS, itemsArr)) return;
+    if (!AddrValid(itemsArr) || listSize <= 0 || listSize > 8192) return;
+
+    int32_t arrMax = 0;
+    SafeRead(itemsArr, OFF_ARR_MAXLEN, arrMax);
+    if (arrMax <= 0 || arrMax > 65536) arrMax = listSize;
+    int32_t cap = (listSize < arrMax) ? listSize : arrMax;
+
+    const uint8_t* itemBase = reinterpret_cast<const uint8_t*>(itemsArr) + OFF_ARR_DATA;
+    for (int32_t i = 0; i < cap; ++i) {
+        void* elem = nullptr;
+        if (!SafeRead(itemBase + static_cast<size_t>(i) * sizeof(void*), 0u, elem) || !AddrValid(elem))
+            continue;
+        TryAppendHbeakFromElem(elem, hbeakKlass, offProjPropsField, out, seenPtrs);
+    }
+}
+
+static void MergeProjectilePoolsFromWorldManager(void* worldMgr, std::vector<WorldProjectile>& out,
+                                                 std::unordered_set<uintptr_t>& seenPtrs)
+{
+    Il2CppClass* hbeak = GetHbeakProjectileClass();
+    if (!hbeak) return;
+
+    const uint32_t offProjProps = RuntimeOffsets::Hbeak_ProjPropsPtr;
+    void* dictA = nullptr;
+    void* dictB = nullptr;
+    void* listKj = nullptr;
+    if (SafeRead(worldMgr, OFF_WM_MAPOBJ_DICT_A, dictA) && AddrValid(dictA))
+        TryMergeProjectileDict(dictA, hbeak, offProjProps, out, seenPtrs);
+    if (SafeRead(worldMgr, OFF_WM_MAPOBJ_DICT_B, dictB) && AddrValid(dictB))
+        TryMergeProjectileDict(dictB, hbeak, offProjProps, out, seenPtrs);
+    if (SafeRead(worldMgr, OFF_WM_KJMON_LIST, listKj) && AddrValid(listKj))
+        TryMergeKjmonProjectileList(listKj, hbeak, offProjProps, out, seenPtrs);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classification helpers
+//
+// Class hierarchy (confirmed from dump):
+//   FKALGHJIADI (sealed) : PMMFLLAIPGN — local player (only subclass of PMMFLLAIPGN)
+//   PMMFLLAIPGN          : LKHPPBEGNOM — all characters: enemies, NPCs, other players
+//   KJMONHENJEN          — tile / terrain base
+//   everything else      — portals, chests, statics (FPMMAILJKBN etc.)
+//
+// "Enemy" = PMMFLLAIPGN (all non–FKALGHJIADI characters in the entity dict).
+// ─────────────────────────────────────────────────────────────────────────────
+static bool IsPlayerClass(const WorldEntity& e)
+{
+    return strcmp(e.typeName, "FKALGHJIADI") == 0;
+}
+
+static bool IsEnemy(const WorldEntity& e)
+{
+    return strcmp(e.typeName, "PMMFLLAIPGN") == 0;
+}
+
+static bool MatchesCat(const WorldEntity& e, EntityCat cat)
+{
+    switch (cat) {
+    case EntityCat::Player: return IsPlayerClass(e);
+    case EntityCat::Enemy:  return IsEnemy(e);
+    case EntityCat::Object: return !IsPlayerClass(e) && !IsEnemy(e) &&
+                                    strcmp(e.typeName, "KJMONHENJEN") != 0;
+    default:                return true;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read a short IL2CPP System.String into a char buffer (ASCII-safe). Returns false if null/empty.
+static bool ReadIl2CppString(void* strPtr, char* buf, int bufLen)
+{
+    if (!AddrValid(strPtr) || bufLen <= 0) return false;
+    int32_t len = 0;
+    SafeRead(strPtr, OFF_STR_LEN, len);
+    if (len <= 0 || len > 256) return false;
+    if (len > bufLen - 1) len = bufLen - 1;
+    const uint8_t* chars = reinterpret_cast<const uint8_t*>(strPtr) + OFF_STR_CHARS;
+    for (int i = 0; i < len; ++i) {
+        uint16_t ch = 0;
+        SafeRead(chars + (size_t)i * 2u, 0u, ch);
+        buf[i] = (char)(ch & 0x7F);
+    }
+    buf[len] = '\0';
+    return buf[0] != '\0';
+}
+
+// Read tile conditions, damage, and speed from a BGAIOPJMHLO instance into a WorldTile.
+// All three are sourced exclusively from the CMFPKCJHKKB XML property strings:
+//   - Speed string null  → no modifier (t.speed = 0)
+//   - Speed string "0.6" → slow tile (< 1.0)
+//   - Speed string "1.4" → fast tile (> 1.0)
+// The raw float at 0x78 (AIDOHEECBOC) is the tile's absolute move speed, NOT a modifier.
+// It is always non-zero, so it was masking speed tiles when used as the primary source.
+static void ReadTileProps(void* tp, WorldTile& t)
+{
+    void* props = nullptr;
+    SafeRead(tp, OFF_TILE_PROPS, props);
+    if (!AddrValid(props)) return;
+
+    void* sinkStr = nullptr, *pushStr = nullptr, *alphaStr = nullptr,
+          *sinkingStr = nullptr, *nowalkStr = nullptr;
+    SafeRead(props, OFF_TP_SINK,    sinkStr);
+    SafeRead(props, OFF_TP_PUSH,    pushStr);
+    SafeRead(props, OFF_TP_ALPHA,   alphaStr);
+    SafeRead(props, OFF_TP_SINKING, sinkingStr);
+    SafeRead(props, OFF_TP_NOWALK,  nowalkStr);
+
+    if (AddrValid(sinkStr))    t.conds |= TCOND_SINK;
+    if (AddrValid(pushStr))    t.conds |= TCOND_PUSH;
+    if (AddrValid(alphaStr))   t.conds |= TCOND_ALPHA;
+    if (AddrValid(sinkingStr)) t.conds |= TCOND_SINKING;
+    if (AddrValid(nowalkStr))  t.conds |= TCOND_NOWALK;
+
+    // Damage: parse from CMFPKCJHKKB XML strings (raw ints at 0x70/0x74 are wrong)
+    {
+        void* minStr = nullptr;
+        SafeRead(props, OFF_TP_MINDMG, minStr);
+        if (AddrValid(minStr)) {
+            char buf[32] = {};
+            if (ReadIl2CppString(minStr, buf, sizeof(buf)))
+                t.minDmg = (int32_t)std::strtol(buf, nullptr, 10);
+        }
+    }
+    {
+        void* maxStr = nullptr;
+        SafeRead(props, OFF_TP_MAXDMG, maxStr);
+        if (AddrValid(maxStr)) {
+            char buf[32] = {};
+            if (ReadIl2CppString(maxStr, buf, sizeof(buf)))
+                t.maxDmg = (int32_t)std::strtol(buf, nullptr, 10);
+        }
+    }
+
+    // Speed: always parse from CMFPKCJHKKB XML string.
+    // t.speed stays 0 (no modifier) if the string is absent.
+    {
+        void* spStr = nullptr;
+        SafeRead(props, OFF_TP_SPEED, spStr);
+        if (AddrValid(spStr)) {
+            char buf[32] = {};
+            if (ReadIl2CppString(spStr, buf, sizeof(buf)))
+                t.speed = std::strtof(buf, nullptr);
+        }
+    }
+}
+
+// Core refresh
+// ─────────────────────────────────────────────────────────────────────────────
+static void DoRefresh()
+{
+    g_entities.clear();
+    g_tiles.clear();
+    g_projectiles.clear();
+    g_localX = g_localY = 0.f;
+
+    // ── Resolve via GameState (single shared AppMgr/WorldMgr cache) ─────────
+    void* appMgr = GameState::GetAppMgr();
+    if (!appMgr) {
+        g_status = "Waiting for GameState to resolve ApplicationManager...";
+        g_statusOk = false; return;
+    }
+    g_appMgrPtr = reinterpret_cast<uintptr_t>(appMgr);
+
+    void* worldMgr = GameState::GetWorldMgr();
+    if (!worldMgr) {
+        g_status = "ERROR: WorldManager not available (GameState).";
+        g_statusOk = false; return;
+    }
+    g_worldMgrPtr = reinterpret_cast<uintptr_t>(worldMgr);
+
+    SafeRead(worldMgr, OFF_WM_UINT_D8,  g_wm_d8);
+    SafeRead(worldMgr, OFF_WM_UINT_DC,  g_wm_dc);
+    SafeRead(worldMgr, OFF_WM_UINT_E0,  g_wm_e0);
+    SafeRead(worldMgr, OFF_WM_FLOAT_F4, g_wm_f4);
+    SafeRead(worldMgr, OFF_WM_FLOAT_F8, g_wm_f8);
+    SafeRead(worldMgr, OFF_WM_INT_FC,   g_wm_fc);
+    SafeRead(worldMgr, OFF_WM_INT_100,  g_wm_100);
+
+    // Local player — read from GameState (already resolved this frame).
+    void* localPtr = GameState::GetLocalPtr();
+    if (localPtr && AddrValid(localPtr)) {
+        g_localPtr = localPtr;
+        SafeRead(localPtr, OFF_POS_X, g_localX);
+        SafeRead(localPtr, OFF_POS_Y, g_localY);
+    }
+
+    // ── Scan entity dict (DFALIKKKGLI @ 0xB0) ───────────────────────────────
+    void* entDictPtr = nullptr;
+    SafeRead(worldMgr, OFF_WM_ALL_DICT, entDictPtr);
+    if (!AddrValid(entDictPtr)) {
+        g_status = "ERROR: Entity dict null (offset 0xB0). Not in-game?"; g_statusOk = false; return;
+    }
+
+    ProjectileTracking::OnWorldRefreshBegin();
+
+    WalkDict(entDictPtr, 4096, [&](int32_t key, void* value) {
+        WorldEntity ent;
+        ent.objectId = key;
+        ent.ptr      = value;
+
+        SafeRead(value, OFF_POS_X,  ent.x);
+        SafeRead(value, OFF_POS_Y,  ent.y);
+        SafeRead(value, OFF_HP,     ent.hp);
+        SafeRead(value, OFF_MAX_HP, ent.maxHp);
+
+        RuntimeOffsets::TryReadMapObjectConditions(value, &ent.condLo, &ent.condHi);
+
+        void* klass = nullptr;
+        if (SafeRead(value, 0u, klass) && AddrValid(klass)) {
+            ent.klass = klass;
+            Resolver::Protection::safe_call([&]() {
+                const char* cn = il2cpp_class_get_name(reinterpret_cast<Il2CppClass*>(klass));
+                if (cn) strncpy_s(ent.typeName, cn, sizeof(ent.typeName) - 1);
+            });
+        }
+
+        // HFDNHJFNEKA (objectType) @ 0x30 — no ACTK shift (same as X/Y)
+        if (ent.typeName[0] && strcmp(ent.typeName, "KJMONHENJEN") != 0)
+            SafeRead(value, 0x30u, ent.objType);
+
+        // Player name — probe multiple candidate offsets to find the IGN string.
+        // H1: 0x4B8 (NFJGJKLPLBA, dump 0x468 + 0x50 ACTK)
+        // H2: 0x4F0 (HKGPJPCHOFF, dump 0x4A0 + 0x50)
+        // H3: 0x520 (CMDGOAAPPGL, dump 0x4D0 + 0x50)
+        // H4: 0x528 (FKIHLOKHKIA, dump 0x4D8 + 0x50)
+        if (strcmp(ent.typeName, "FKALGHJIADI") == 0) {
+            // IGN: DPGEBOCBKEF @ 0x178 (no ACTK shift — confirmed by blind scan)
+            void* nameStr = nullptr;
+            if (SafeRead(value, OFF_PLAYER_IGN, nameStr) && AddrValid(nameStr))
+                ReadIl2CppString(nameStr, ent.playerName, sizeof(ent.playerName));
+        }
+
+        // XML object name + conditions via KJMONHENJEN.OBAKMCCDBJA @ 0x18 → ObjectProperties
+        {
+            void* op = nullptr;
+            if (SafeRead(value, OFF_KJM_OBJPROPS, op) && AddrValid(op)) {
+                // Name
+                void* idStr = nullptr;
+                if (SafeRead(op, OFF_OP_ID_STR, idStr) && AddrValid(idStr))
+                    ReadIl2CppString(idStr, ent.objName, sizeof(ent.objName));
+                // ObjectProperties condition fields are not real XML conditions on players
+                // (FKALGHJIADI); memory may still expose flags — leave objConds blank until mapped elsewhere.
+                if (!IsPlayerClass(ent)) {
+                    uint8_t b = 0;
+                    if (SafeRead(op, OFF_OP_OCCUPY_SQ,  b) && b) ent.objConds |= OCOND_OCCUPY_SQ;
+                    if (SafeRead(op, OFF_OP_FULL_OCC,   b) && b) ent.objConds |= OCOND_FULL_OCC;
+                    if (SafeRead(op, OFF_OP_ENEMY_OCC,  b) && b) ent.objConds |= OCOND_ENEMY_OCC;
+                    if (SafeRead(op, OFF_OP_IS_ENEMY,   b) && b) ent.objConds |= OCOND_IS_ENEMY;
+                    if (SafeRead(op, OFF_OP_IS_STATIC,  b) && b) ent.objConds |= OCOND_STATIC;
+                    if (SafeRead(op, OFF_OP_BLOCK_PROJ, b) && b) ent.objConds |= OCOND_BLOCK_PROJ;
+                    if (SafeRead(op, OFF_OP_PROT_GND,   b) && b) ent.objConds |= OCOND_PROT_GND;
+                    if (SafeRead(op, OFF_OP_PROT_SINK,  b) && b) ent.objConds |= OCOND_PROT_SINK;
+                    if (SafeRead(op, OFF_OP_FLYING,     b) && b) ent.objConds |= OCOND_FLYING;
+                    // String element conditions (non-null pointer = flag set)
+                    void* sp = nullptr;
+                    if (SafeRead(op, OFF_OP_NOCOVER,    sp) && AddrValid(sp)) ent.objConds |= OCOND_NO_COVER;
+                    if (SafeRead(op, OFF_OP_NOWALL_RPT, sp) && AddrValid(sp)) ent.objConds |= OCOND_NO_WALL_RPT;
+                    // connectType int (non-zero = Connects)
+                    int32_t ct = 0;
+                    if (SafeRead(op, OFF_OP_CONNECT_T,  ct) && ct != 0) ent.objConds |= OCOND_CONNECTS;
+                }
+            }
+        }
+
+        if (localPtr && value == localPtr) {
+            ent.isLocal = true;
+            SafeRead(value, OFF_POS_X, g_localX);
+            SafeRead(value, OFF_POS_Y, g_localY);
+            ProjectileTracking::SetLocalPlayerObjectId(key);
+        }
+
+        ProjectileTracking::OnWorldEntity(key, ent.x, ent.y);
+
+        g_entities.push_back(ent);
+    });
+
+    if (localPtr && AddrValid(localPtr) && ProjectileTracking::GetLocalPlayerObjectId() == 0) {
+        int32_t oidFromField = 0;
+        if (SafeRead(localPtr, OFF_KJM_OBJECT_ID, oidFromField) && oidFromField != 0)
+            ProjectileTracking::SetLocalPlayerObjectId(oidFromField);
+    }
+
+    // ── Scan tiles: BGAIOPJMHLO[] NOJEHIAOAJM @ wm+0x58
+    // H-A: array holds all received ground tiles (size and X/Y/type valid)
+    // H-B: List<BGAIOPJMHLO> IMAOBDCMPHC @ wm+0x60 may hold same/subset
+    // H-C: ushort tileType @ tile+0x40 is non-zero
+    // H-D: int tileX/Y @ tile+0x38/0x3C are integer grid coords
+    void* tileArrPtr  = nullptr;
+    void* tileListPtr = nullptr;
+    SafeRead(worldMgr, OFF_WM_TILE_ARR,  tileArrPtr);
+    SafeRead(worldMgr, OFF_WM_TILE_LIST, tileListPtr);
+
+    int32_t arrLen    = 0;
+    int32_t listSize  = 0;
+    void*   listItems = nullptr;
+
+    if (AddrValid(tileArrPtr))
+        SafeRead(tileArrPtr, OFF_ARR_MAXLEN, arrLen);
+    if (AddrValid(tileListPtr)) {
+        SafeRead(tileListPtr, OFF_LIST_SIZE, listSize);
+        SafeRead(tileListPtr, OFF_LIST_ITEMS, listItems);
+    }
+
+    // CONFIRMED by logs:
+    // - Array @ 0x58 (arrLen=65536=256x256 spatial grid): most entries are type=255 (PFHFAHFGIOB=void/empty).
+    // - List  @ 0x60 (listSize grows as you move): accumulates ALL received tiles with valid type IDs.
+    // → Use the List as the primary source; also pull array but skip type=255.
+    static constexpr uint16_t TILE_VOID = 255;   // BGAIOPJMHLO.PFHFAHFGIOB = 255 = unset/void
+
+    // Primary: List<BGAIOPJMHLO> @ wm+0x60 — all tiles received this session
+    if (AddrValid(listItems) && listSize > 0) {
+        int32_t cap = listSize < (int32_t)MAX_TILES ? listSize : (int32_t)MAX_TILES;
+        const uint8_t* base = reinterpret_cast<const uint8_t*>(listItems) + OFF_ARR_DATA;
+        for (int32_t i = 0; i < cap; ++i) {
+            void* tp = nullptr;
+            if (!SafeRead(base + (size_t)i * sizeof(void*), 0u, tp) || !AddrValid(tp)) continue;
+            WorldTile t;
+            t.ptr = tp;
+            SafeRead(tp, OFF_TILE_X,    t.tileX);
+            SafeRead(tp, OFF_TILE_Y,    t.tileY);
+            SafeRead(tp, OFF_TILE_TYPE, t.tileType);
+            if (t.tileType == TILE_VOID) continue;   // skip void/unset slots
+            ReadTileProps(tp, t);
+            // Tile XML name via same chain as entities: KJMONHENJEN.OBAKMCCDBJA[0x18] → ObjectProperties.id[0x38]
+            {
+                void* op = nullptr;
+                void* idStr = nullptr;
+                if (SafeRead(tp, OFF_KJM_OBJPROPS, op) && AddrValid(op) &&
+                    SafeRead(op, OFF_OP_ID_STR, idStr) && AddrValid(idStr))
+                    ReadIl2CppString(idStr, t.tileName, sizeof(t.tileName));
+            }
+            g_tiles.push_back(t);
+        }
+    }
+
+
+    RebuildBlockedMap();
+
+    ProjectileTracking::SnapshotToWorld(g_projectiles);
+    std::unordered_set<uintptr_t> projPtrSeen;
+    projPtrSeen.reserve(g_projectiles.size() + 64);
+    for (const WorldProjectile& p : g_projectiles)
+        projPtrSeen.insert(reinterpret_cast<uintptr_t>(p.ptr));
+    MergeProjectilePoolsFromWorldManager(worldMgr, g_projectiles, projPtrSeen);
+
+    char buf[160];
+    snprintf(buf, sizeof(buf),
+        "Objects: %zu  |  Tiles: %zu  |  Projectiles: %zu (ring %d)  |  WM dict+0x%X list+0x%X + hook",
+        g_entities.size(), g_tiles.size(), g_projectiles.size(),
+        ProjectileTracking::CountValidForDiagnostics(), OFF_WM_MAPOBJ_DICT_A, OFF_WM_KJMON_LIST);
+    g_status   = buf;
+    g_statusOk = true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// World inspect: editable primitive fields (match UnityExplorerTAB patterns).
+// ─────────────────────────────────────────────────────────────────────────────
+static bool WorldInspectFieldIsStatic(FieldInfo* f)
+{
+    return f && f->type && ((f->type->attrs & 0x0010) != 0);
+}
+
+static void WorldInspectApplyFieldValue(Il2CppObject* obj, FieldInfo* f, bool isStatic, const void* buf)
+{
+    if (isStatic) il2cpp_field_static_set_value(f, const_cast<void*>(buf));
+    else if (obj) il2cpp_field_set_value(obj, f, const_cast<void*>(buf));
+}
+
+static void DrawWorldInspectEditableFieldValue(Il2CppObject* obj, FieldInfo* f)
+{
+    if (!f || !f->type) {
+        ImGui::TextUnformatted("?");
+        return;
+    }
+    if (il2cpp_field_is_literal(f)) {
+        ImGui::TextUnformatted(Resolver::FormatFieldValueAsText(obj, f).c_str());
+        return;
+    }
+
+    const bool isStatic = WorldInspectFieldIsStatic(f);
+    if (!isStatic && !obj) {
+        ImGui::TextDisabled("null");
+        return;
+    }
+
+    const Il2CppType* ft   = il2cpp_field_get_type(f);
+    const int         typeEnum = il2cpp_type_get_type(ft);
+
+    ImGui::PushItemWidth(-1.f);
+
+    switch (typeEnum) {
+    case IL2CPP_TYPE_BOOLEAN: {
+        bool v = false;
+        Resolver::GetFieldValue(obj, f, &v);
+        const char* items[] = { "false", "true" };
+        int         i       = v ? 1 : 0;
+        if (ImGui::Combo("##wfBool", &i, items, IM_ARRAYSIZE(items))) {
+            v = (i != 0);
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        }
+        break;
+    }
+    case IL2CPP_TYPE_I1: {
+        int8_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        int iv = v;
+        if (ImGui::InputInt("##wfI1", &iv, 1, 10, ImGuiInputTextFlags_CharsDecimal)) {
+            if (iv < -128) iv = -128;
+            if (iv > 127) iv = 127;
+            v = static_cast<int8_t>(iv);
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        }
+        break;
+    }
+    case IL2CPP_TYPE_U1: {
+        uint8_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        int iv = v;
+        if (ImGui::InputInt("##wfU1", &iv, 1, 10, ImGuiInputTextFlags_CharsDecimal)) {
+            if (iv < 0) iv = 0;
+            if (iv > 255) iv = 255;
+            v = static_cast<uint8_t>(iv);
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        }
+        break;
+    }
+    case IL2CPP_TYPE_I2: {
+        int16_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        int iv = v;
+        if (ImGui::InputInt("##wfI2", &iv, 1, 100, ImGuiInputTextFlags_CharsDecimal)) {
+            if (iv < -32768) iv = -32768;
+            if (iv > 32767) iv = 32767;
+            v = static_cast<int16_t>(iv);
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        }
+        break;
+    }
+    case IL2CPP_TYPE_U2:
+    case IL2CPP_TYPE_CHAR: {
+        uint16_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        int iv = v;
+        if (ImGui::InputInt("##wfU2", &iv, 1, 100, ImGuiInputTextFlags_CharsDecimal)) {
+            if (iv < 0) iv = 0;
+            if (iv > 65535) iv = 65535;
+            v = static_cast<uint16_t>(iv);
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        }
+        break;
+    }
+    case IL2CPP_TYPE_I4:
+    case IL2CPP_TYPE_ENUM: {
+        int32_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (ImGui::InputInt("##wfI4", &v, 1, 100, ImGuiInputTextFlags_CharsDecimal))
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        break;
+    }
+    case IL2CPP_TYPE_U4: {
+        uint32_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (ImGui::InputScalar("##wfU4", ImGuiDataType_U32, &v, nullptr, nullptr, "%u",
+                ImGuiInputTextFlags_CharsDecimal))
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        break;
+    }
+    case IL2CPP_TYPE_I8: {
+        int64_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (ImGui::InputScalar("##wfI8", ImGuiDataType_S64, &v, nullptr, nullptr, nullptr,
+                ImGuiInputTextFlags_CharsDecimal))
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        break;
+    }
+    case IL2CPP_TYPE_U8: {
+        uint64_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (ImGui::InputScalar("##wfU8", ImGuiDataType_U64, &v, nullptr, nullptr, nullptr,
+                ImGuiInputTextFlags_CharsDecimal))
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        break;
+    }
+    case IL2CPP_TYPE_R4: {
+        float v = 0.f;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (ImGui::InputFloat("##wfR4", &v, 0.f, 0.f, "%.9g", ImGuiInputTextFlags_CharsDecimal))
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        break;
+    }
+    case IL2CPP_TYPE_R8: {
+        double v = 0.0;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (ImGui::InputDouble("##wfR8", &v, 0.0, 0.0, "%.17g", ImGuiInputTextFlags_CharsDecimal))
+            WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+        break;
+    }
+    case IL2CPP_TYPE_I: {
+        intptr_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (sizeof(intptr_t) == 8) {
+            int64_t vv = static_cast<int64_t>(v);
+            if (ImGui::InputScalar("##wfIP", ImGuiDataType_S64, &vv, nullptr, nullptr, nullptr,
+                    ImGuiInputTextFlags_CharsDecimal)) {
+                v = static_cast<intptr_t>(vv);
+                WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+            }
+        } else {
+            int32_t vv = static_cast<int32_t>(v);
+            if (ImGui::InputInt("##wfIP", &vv, 1, 100, ImGuiInputTextFlags_CharsDecimal)) {
+                v = static_cast<intptr_t>(vv);
+                WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+            }
+        }
+        break;
+    }
+    case IL2CPP_TYPE_U: {
+        uintptr_t v = 0;
+        Resolver::GetFieldValue(obj, f, &v);
+        if (sizeof(uintptr_t) == 8) {
+            uint64_t vv = static_cast<uint64_t>(v);
+            if (ImGui::InputScalar("##wfUP", ImGuiDataType_U64, &vv, nullptr, nullptr, nullptr,
+                    ImGuiInputTextFlags_CharsDecimal)) {
+                v = static_cast<uintptr_t>(vv);
+                WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+            }
+        } else {
+            uint32_t vv = static_cast<uint32_t>(v);
+            if (ImGui::InputScalar("##wfUP", ImGuiDataType_U32, &vv, nullptr, nullptr, nullptr,
+                    ImGuiInputTextFlags_CharsDecimal)) {
+                v = static_cast<uintptr_t>(vv);
+                WorldInspectApplyFieldValue(obj, f, isStatic, &v);
+            }
+        }
+        break;
+    }
+    case IL2CPP_TYPE_STRING: {
+        const uint64_t key = WorldInspectStrFieldKey(obj, f, isStatic);
+        std::vector<char>& buf = s_worldInspectStrFieldBufs[key];
+        if (buf.empty()) {
+            Il2CppString* s = nullptr;
+            Resolver::GetFieldValue(obj, f, &s);
+            const std::string cur = s ? il2cppi_to_string(s) : std::string();
+            const size_t cap = (std::max)(size_t{ 256 }, cur.size() + 128);
+            buf.resize(cap);
+            strncpy_s(buf.data(), buf.size(), cur.c_str(), _TRUNCATE);
+        }
+        ImGui::InputText("##wfStr", buf.data(), buf.size(),
+            ImGuiInputTextFlags_CallbackResize,
+            WorldInspectInputTextResizeCallback, &buf);
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            Il2CppString* ns = il2cpp_string_new(buf.data());
+            WorldInspectApplyFieldValue(obj, f, isStatic, &ns);
+        }
+        break;
+    }
+    default:
+        ImGui::PushTextWrapPos(0.f);
+        ImGui::TextUnformatted(Resolver::FormatFieldValueAsText(obj, f).c_str());
+        ImGui::PopTextWrapPos();
+        break;
+    }
+
+    ImGui::PopItemWidth();
+}
+
+static void DrawWorldInspectEditableProperty(Il2CppObject* obj, const PropertyInfo* prop)
+{
+    if (!prop || !prop->get) {
+        ImGui::TextUnformatted("?");
+        return;
+    }
+
+    const Il2CppType* rt = prop->get->return_type;
+    if (!rt) {
+        ImGui::TextUnformatted("?");
+        return;
+    }
+
+    const int typeEnum = il2cpp_type_get_type(rt);
+    Il2CppObject* boxed =
+        Resolver::Protection::SafeRuntimeInvoke(prop->get, obj, nullptr);
+
+    ImGui::PushItemWidth(-1.f);
+
+    auto invokeSet = [&](void* pVal) {
+        if (!prop->set) return;
+        void* params[] = { pVal };
+        Resolver::Protection::SafeRuntimeInvoke(prop->set, obj, params);
+    };
+
+    switch (typeEnum) {
+    case IL2CPP_TYPE_BOOLEAN: {
+        bool v = Resolver::Protection::SafeUnbox<bool>(boxed, false);
+        const char* items[] = { "false", "true" };
+        int         i       = v ? 1 : 0;
+        if (ImGui::Combo("##wpBool", &i, items, IM_ARRAYSIZE(items)) && prop->set) {
+            v = (i != 0);
+            invokeSet(&v);
+        }
+        break;
+    }
+    case IL2CPP_TYPE_I4:
+    case IL2CPP_TYPE_ENUM: {
+        int32_t v = Resolver::Protection::SafeUnbox<int32_t>(boxed, 0);
+        if (ImGui::InputInt("##wpI4", &v, 1, 100, ImGuiInputTextFlags_CharsDecimal) && prop->set)
+            invokeSet(&v);
+        break;
+    }
+    case IL2CPP_TYPE_U4: {
+        uint32_t v = Resolver::Protection::SafeUnbox<uint32_t>(boxed, 0u);
+        if (ImGui::InputScalar("##wpU4", ImGuiDataType_U32, &v, nullptr, nullptr, "%u",
+                ImGuiInputTextFlags_CharsDecimal) &&
+            prop->set)
+            invokeSet(&v);
+        break;
+    }
+    case IL2CPP_TYPE_R4: {
+        float v = Resolver::Protection::SafeUnbox<float>(boxed, 0.f);
+        if (ImGui::InputFloat("##wpR4", &v, 0.f, 0.f, "%.9g", ImGuiInputTextFlags_CharsDecimal) &&
+            prop->set)
+            invokeSet(&v);
+        break;
+    }
+    case IL2CPP_TYPE_R8: {
+        double v = Resolver::Protection::SafeUnbox<double>(boxed, 0.0);
+        if (ImGui::InputDouble("##wpR8", &v, 0.0, 0.0, "%.17g", ImGuiInputTextFlags_CharsDecimal) &&
+            prop->set)
+            invokeSet(&v);
+        break;
+    }
+    case IL2CPP_TYPE_STRING: {
+        if (!prop->set) {
+            const std::string pval =
+                boxed ? il2cppi_to_string(reinterpret_cast<Il2CppString*>(boxed)) : std::string("(null)");
+            ImGui::PushTextWrapPos(0.f);
+            ImGui::TextUnformatted(pval.c_str());
+            ImGui::PopTextWrapPos();
+            break;
+        }
+        const uint64_t key = WorldInspectStrPropKey(obj, prop);
+        std::vector<char>& buf = s_worldInspectStrPropBufs[key];
+        if (buf.empty()) {
+            const std::string cur =
+                boxed ? il2cppi_to_string(reinterpret_cast<Il2CppString*>(boxed)) : std::string();
+            const size_t cap = (std::max)(size_t{ 256 }, cur.size() + 128);
+            buf.resize(cap);
+            strncpy_s(buf.data(), buf.size(), cur.c_str(), _TRUNCATE);
+        }
+        ImGui::InputText("##wpStr", buf.data(), buf.size(),
+            ImGuiInputTextFlags_CallbackResize,
+            WorldInspectInputTextResizeCallback, &buf);
+        if (ImGui::IsItemDeactivatedAfterEdit()) {
+            Il2CppString* ns = il2cpp_string_new(buf.data());
+            void* params[] = { ns };
+            Resolver::Protection::SafeRuntimeInvoke(prop->set, obj, params);
+        }
+        break;
+    }
+    default: {
+        std::string pval = Resolver::FormatIl2CppReturn(prop->get, boxed);
+        ImGui::PushTextWrapPos(0.f);
+        ImGui::TextUnformatted(pval.c_str());
+        ImGui::PopTextWrapPos();
+        break;
+    }
+    }
+
+    ImGui::PopItemWidth();
+}
+
+static const char* WorldInspectFilterTrim(const char* s)
+{
+    if (!s) return "";
+    while (*s == ' ') ++s;
+    return s;
+}
+
+static bool WorldInspectFilterActive()
+{
+    return WorldInspectFilterTrim(s_worldInspectSearchBuf)[0] != '\0';
+}
+
+static bool WorldInspectMatchesFilter(const std::string& displayName, const char* rawName)
+{
+    const char* needle = WorldInspectFilterTrim(s_worldInspectSearchBuf);
+    if (!needle[0]) return true;
+
+    std::string n(needle);
+    for (char& c : n)
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+    auto toLower = [](std::string x) {
+        for (char& c : x)
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        return x;
+    };
+
+    if (toLower(displayName).find(n) != std::string::npos) return true;
+    if (rawName && rawName[0] && toLower(std::string(rawName)).find(n) != std::string::npos) return true;
+    return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Modal: IL2CPP field dump for a double-clicked entity / projectile pointer
+// ─────────────────────────────────────────────────────────────────────────────
+static void DrawWorldInspectPopupModal()
+{
+    if (s_worldInspectPopupRootId == 0)
+        return;
+
+    ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_FirstUseEver, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(580.f, 460.f), ImGuiCond_FirstUseEver);
+    // Do not use AlwaysAutoResize here: it fights SetNextWindowSize and can collapse the scroll child to ~0 height.
+    if (!ImGui::BeginPopupEx(s_worldInspectPopupRootId,
+            ImGuiWindowFlags_Modal | ImGuiWindowFlags_NoCollapse)) {
+        return;
+    }
+
+    if (ImGui::IsWindowAppearing()) {
+        s_worldInspectStrFieldBufs.clear();
+        s_worldInspectStrPropBufs.clear();
+    }
+
+    if (!s_worldInspectObj || !Resolver::Protection::IsValidIl2CppObject(s_worldInspectObj)) {
+        ImGui::TextColored(ImVec4(1.f, 0.45f, 0.35f, 1.f),
+            "Pointer is null, stale, or not a valid Il2CppObject. Close and double-click again after Refresh.");
+    }
+    else {
+        Il2CppClass* klass = nullptr;
+        Resolver::Protection::safe_call([&]() {
+            klass = il2cpp_object_get_class(s_worldInspectObj);
+        });
+        if (!klass) {
+            ImGui::TextColored(ImVec4(1.f, 0.45f, 0.35f, 1.f), "Could not read object class.");
+        }
+        else {
+            const char* cn = il2cpp_class_get_name(klass);
+            const char* ns = il2cpp_class_get_namespace(klass);
+            ImGui::Text("ObjectId: %d", s_worldInspectObjectId);
+            ImGui::Text("Ptr: 0x%p", (void*)s_worldInspectObj);
+            if (s_worldInspectSubtitle[0])
+                ImGui::TextDisabled("%s", s_worldInspectSubtitle);
+            ImGui::TextColored(ImVec4(0.45f, 0.95f, 0.55f, 1.f), "Class: %s%s%s",
+                (ns && ns[0]) ? ns : "",
+                (ns && ns[0]) ? "::" : "",
+                cn ? Beebyte::Deobf(cn).c_str() : "?");
+            ImGui::Separator();
+            ImGui::TextDisabled(
+                "Bools: false/true. Numbers & strings: edit in place; string writes apply when you leave the field "
+                "(Tab/click away). References / structs: read-only. Refresh may invalidate the pointer.");
+            ImGui::Spacing();
+            ImGui::SetNextItemWidth(-1.f);
+            ImGui::InputTextWithHint("##wInspectSearch", "Search fields, properties, methods (name, case-insensitive)...",
+                s_worldInspectSearchBuf, IM_ARRAYSIZE(s_worldInspectSearchBuf));
+            ImGui::Spacing();
+
+            // Walk to root via parents only — do not use il2cpp_defaults (not linked in this DLL).
+            std::vector<Il2CppClass*> hierarchy;
+            for (Il2CppClass* k = klass; k; k = il2cpp_class_get_parent(k))
+                hierarchy.push_back(k);
+            std::reverse(hierarchy.begin(), hierarchy.end());
+
+            // Fixed-height scroll region (fractional height with AutoResize parent produced an empty body).
+            ImGui::BeginChild("WorldInspectScroll", ImVec2(0.f, 320.f), true);
+            for (Il2CppClass* k : hierarchy) {
+                ImGui::PushID((void*)k);
+                const char* kn = il2cpp_class_get_name(k);
+                const char* kns = il2cpp_class_get_namespace(k);
+                std::string header = (kns && kns[0]) ? (std::string(kns) + "::" + Beebyte::Deobf(kn)) : Beebyte::Deobf(kn);
+                if (header.empty() && kn) header = kn;
+                if (header.empty()) header = "?";
+                if (ImGui::CollapsingHeader(header.c_str(), ImGuiTreeNodeFlags_DefaultOpen)) {
+                    ImGui::Indent(8.f);
+                    constexpr ImGuiTableFlags tf =
+                        ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp;
+                    if (ImGui::BeginTable("fld", 2, tf, ImVec2(-1.f, 0.f))) {
+                        ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthStretch, 0.38f);
+                        ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch, 0.62f);
+                        ImGui::TableHeadersRow();
+
+                        void* fIter = nullptr;
+                        bool    anyField = false;
+                        while (FieldInfo* f = il2cpp_class_get_fields(k, &fIter)) {
+                            const char* fname = il2cpp_field_get_name(f);
+                            std::string fdisp = fname ? Beebyte::Deobf(fname) : "?";
+                            if (!WorldInspectMatchesFilter(fdisp, fname))
+                                continue;
+                            anyField = true;
+                            ImGui::TableNextRow();
+                            ImGui::PushID(f);
+                            ImGui::TableNextColumn();
+                            const bool isStatic = WorldInspectFieldIsStatic(f);
+                            if (isStatic)
+                                ImGui::TextColored(ImVec4(1.f, 0.92f, 0.5f, 1.f), "(S) %s", fdisp.c_str());
+                            else
+                                ImGui::TextUnformatted(fdisp.c_str());
+
+                            ImGui::TableNextColumn();
+                            DrawWorldInspectEditableFieldValue(s_worldInspectObj, f);
+                            ImGui::PopID();
+                        }
+                        if (WorldInspectFilterActive() && !anyField) {
+                            ImGui::TableNextRow();
+                            ImGui::TableNextColumn();
+                            ImGui::TextDisabled("(no matching fields)");
+                            ImGui::TableNextColumn();
+                            ImGui::TextDisabled("");
+                        }
+                        ImGui::EndTable();
+                    }
+                    ImGui::Spacing();
+                    ImGui::TextDisabled("Properties");
+                    if (ImGui::BeginTable("pr", 2, tf, ImVec2(-1.f, 0.f))) {
+                        ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_WidthStretch, 0.38f);
+                        ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch, 0.62f);
+                        ImGui::TableHeadersRow();
+                        void* pIter = nullptr;
+                        bool  anyProp = false;
+                        while (const PropertyInfo* prop = il2cpp_class_get_properties(k, &pIter)) {
+                            if (!prop->get) continue;
+                            const char* pname = il2cpp_property_get_name(const_cast<PropertyInfo*>(prop));
+                            std::string pdisp = pname ? Beebyte::Deobf(pname) : std::string("?");
+                            if (!WorldInspectMatchesFilter(pdisp, pname))
+                                continue;
+                            anyProp = true;
+                            ImGui::TableNextRow();
+                            ImGui::PushID(prop);
+                            ImGui::TableNextColumn();
+                            ImGui::TextUnformatted(pdisp.c_str());
+                            ImGui::TableNextColumn();
+                            DrawWorldInspectEditableProperty(s_worldInspectObj, prop);
+                            ImGui::PopID();
+                        }
+                        if (WorldInspectFilterActive() && !anyProp) {
+                            ImGui::TableNextRow();
+                            ImGui::TableNextColumn();
+                            ImGui::TextDisabled("(no matching properties)");
+                            ImGui::TableNextColumn();
+                            ImGui::TextDisabled("");
+                        }
+                        ImGui::EndTable();
+                    }
+                    ImGui::Spacing();
+                    ImGui::TextDisabled("Methods");
+                    if (ImGui::BeginTable("mtd", 3, tf, ImVec2(-1.f, 0.f))) {
+                        ImGui::TableSetupColumn("Method", ImGuiTableColumnFlags_WidthStretch, 0.52f);
+                        ImGui::TableSetupColumn("#args", ImGuiTableColumnFlags_WidthFixed, 48.f);
+                        ImGui::TableSetupColumn("Native", ImGuiTableColumnFlags_WidthStretch, 0.36f);
+                        ImGui::TableHeadersRow();
+
+                        void*       mIter = nullptr;
+                        bool        anyMethod = false;
+                        while (const MethodInfo* mi = il2cpp_class_get_methods(k, &mIter)) {
+                            const char* mname = il2cpp_method_get_name(mi);
+                            std::string mdisp = mname ? Beebyte::Deobf(mname) : std::string("?");
+                            if (!WorldInspectMatchesFilter(mdisp, mname))
+                                continue;
+                            anyMethod = true;
+                            ImGui::TableNextRow();
+                            ImGui::PushID(mi);
+                            ImGui::TableNextColumn();
+                            const bool isInstance = il2cpp_method_is_instance(mi);
+                            if (isInstance)
+                                ImGui::TextUnformatted(mdisp.c_str());
+                            else
+                                ImGui::TextColored(ImVec4(1.f, 0.92f, 0.5f, 1.f), "(S) %s", mdisp.c_str());
+                            ImGui::TableNextColumn();
+                            const uint32_t npc = il2cpp_method_get_param_count(mi);
+                            ImGui::Text("%u", (unsigned)npc);
+                            ImGui::TableNextColumn();
+                            void* mptr = nullptr;
+                            Resolver::Protection::safe_call([&]() {
+                                mptr = reinterpret_cast<void*>(mi->methodPointer);
+                            });
+                            if (mptr)
+                                ImGui::TextDisabled("0x%llX", (unsigned long long)(uintptr_t)mptr);
+                            else
+                                ImGui::TextDisabled("—");
+                            ImGui::PopID();
+                        }
+                        if (WorldInspectFilterActive() && !anyMethod) {
+                            ImGui::TableNextRow();
+                            ImGui::TableNextColumn();
+                            ImGui::TextDisabled("(no matching methods)");
+                            ImGui::TableNextColumn();
+                            ImGui::TextDisabled("");
+                            ImGui::TableNextColumn();
+                            ImGui::TextDisabled("");
+                        }
+                        ImGui::EndTable();
+                    }
+                    ImGui::Unindent(8.f);
+                }
+                ImGui::PopID();
+            }
+            ImGui::EndChild();
+        }
+    }
+
+    ImGui::Spacing();
+    if (ImGui::Button("Close", ImVec2(120.f, 0.f))) {
+        s_worldInspectObj = nullptr;
+        s_worldInspectSubtitle[0] = '\0';
+        ImGui::CloseCurrentPopup();
+    }
+    ImGui::EndPopup();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Draw the entity table (used inside the entity view)
+// ─────────────────────────────────────────────────────────────────────────────
+static void DrawEntityTable(const std::vector<const WorldEntity*>& shown)
+{
+    static constexpr ImGuiTableFlags kFlags =
+        ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+        ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable |
+        ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingFixedFit;
+
+    if (!ImGui::BeginTable("EntTable", 11, kFlags, ImGui::GetContentRegionAvail()))
+        return;
+
+    ImGui::TableSetupScrollFreeze(0, 1);
+    ImGui::TableSetupColumn("Ptr",     ImGuiTableColumnFlags_WidthFixed, 138.f);
+    ImGui::TableSetupColumn("ID",      ImGuiTableColumnFlags_WidthFixed,  64.f);
+    ImGui::TableSetupColumn("Class",   ImGuiTableColumnFlags_WidthFixed, 120.f);
+    ImGui::TableSetupColumn("ObjType", ImGuiTableColumnFlags_WidthFixed, 100.f);
+    ImGui::TableSetupColumn("X",       ImGuiTableColumnFlags_WidthFixed,  62.f);
+    ImGui::TableSetupColumn("Y",       ImGuiTableColumnFlags_WidthFixed,  62.f);
+    ImGui::TableSetupColumn("HP",      ImGuiTableColumnFlags_WidthFixed, 150.f);
+    ImGui::TableSetupColumn("Dist",    ImGuiTableColumnFlags_WidthFixed,  52.f);
+    ImGui::TableSetupColumn("Name",    ImGuiTableColumnFlags_WidthFixed, 140.f);
+    ImGui::TableSetupColumn("IGN",     ImGuiTableColumnFlags_WidthFixed, 120.f);
+    ImGui::TableSetupColumn("Conds",   ImGuiTableColumnFlags_WidthStretch,  0.f);
+    ImGui::TableHeadersRow();
+
+    for (const WorldEntity* e : shown) {
+        ImGui::TableNextRow();
+        if (e->isLocal)
+            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                ImGui::GetColorU32(ImVec4(0.10f, 0.35f, 0.10f, 0.80f)));
+        else if (IsEnemy(*e))
+            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                ImGui::GetColorU32(ImVec4(0.35f, 0.08f, 0.08f, 0.50f)));
+
+        // Ptr
+        ImGui::TableNextColumn();
+        {
+            char ptrbuf[24];
+            snprintf(ptrbuf, sizeof(ptrbuf), "0x%llX", (unsigned long long)e->ptr);
+            ImGui::TextDisabled("%s", ptrbuf);
+            if (ImGui::IsItemClicked()) ImGui::SetClipboardText(ptrbuf);
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Click to copy address\nDouble-click: inspect fields (popup)");
+            if (e->ptr && Resolver::Protection::IsValidIl2CppObject((Il2CppObject*)e->ptr)) {
+                if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+                    s_worldInspectObj = (Il2CppObject*)e->ptr;
+                    s_worldInspectObjectId = e->objectId;
+                    if (e->typeName[0])
+                        strncpy_s(s_worldInspectSubtitle, e->typeName, _TRUNCATE);
+                    else
+                        s_worldInspectSubtitle[0] = '\0';
+                    ImGui::OpenPopupEx(s_worldInspectPopupRootId, ImGuiPopupFlags_None);
+                }
+            }
+        }
+        // ID
+        ImGui::TableNextColumn();
+        if (e->isLocal)
+            ImGui::TextColored(ImVec4(0.4f, 1.f, 0.4f, 1.f), "%d*", e->objectId);
+        else
+            ImGui::Text("%d", e->objectId);
+        // Class
+        ImGui::TableNextColumn();
+        if (e->typeName[0]) ImGui::TextUnformatted(e->typeName);
+        else                ImGui::TextDisabled("?");
+        // ObjType
+        ImGui::TableNextColumn();
+        if (e->objType != 0)
+            ImGui::Text("%d (0x%X)", e->objType, (uint32_t)e->objType);
+        else if (e->typeName[0] && strcmp(e->typeName, "KJMONHENJEN") != 0)
+            ImGui::TextDisabled("0");
+        else
+            ImGui::TextDisabled("--");
+        // X / Y
+        ImGui::TableNextColumn(); ImGui::Text("%.1f", e->x);
+        ImGui::TableNextColumn(); ImGui::Text("%.1f", e->y);
+        // HP bar
+        ImGui::TableNextColumn();
+        if (e->maxHp > 0) {
+            float frac = static_cast<float>(e->hp) / static_cast<float>(e->maxHp);
+            frac = frac < 0.f ? 0.f : frac > 1.f ? 1.f : frac;
+            ImVec4 col = frac > 0.60f ? ImVec4(0.20f, 0.80f, 0.20f, 1.f)
+                       : frac > 0.30f ? ImVec4(0.90f, 0.70f, 0.10f, 1.f)
+                       :                ImVec4(0.90f, 0.20f, 0.20f, 1.f);
+            char hpbuf[32]; snprintf(hpbuf, sizeof(hpbuf), "%d / %d", e->hp, e->maxHp);
+            ImGui::PushStyleColor(ImGuiCol_PlotHistogram, col);
+            ImGui::ProgressBar(frac, ImVec2(-1.f, 13.f), hpbuf);
+            ImGui::PopStyleColor();
+        } else {
+            ImGui::TextDisabled("N/A");
+        }
+        // Dist
+        ImGui::TableNextColumn();
+        if (e->isLocal) ImGui::TextDisabled("--");
+        else            ImGui::Text("%.1f", Distance(e->x, e->y, g_localX, g_localY));
+        // Name — XML id from ObjectProperties (e.g. "Cyclops God", "Wizard")
+        ImGui::TableNextColumn();
+        if (e->objName[0]) ImGui::TextUnformatted(e->objName);
+        else               ImGui::TextDisabled("--");
+        // IGN — player account name (FKALGHJIADI only)
+        ImGui::TableNextColumn();
+        if (e->playerName[0])
+            ImGui::TextColored(ImVec4(0.7f, 0.9f, 1.f, 1.f), "%s", e->playerName);
+        else
+            ImGui::TextDisabled("--");
+        // Object XML flags + MapObject status conditions (COHCKAPOLCA / offset_map.md)
+        ImGui::TableNextColumn();
+        {
+            char cbuf[384] = {};
+            if (e->objConds) {
+                if (e->objConds & OCOND_STATIC)      strcat_s(cbuf, sizeof cbuf, "Static ");
+                if (e->objConds & OCOND_IS_ENEMY)    strcat_s(cbuf, sizeof cbuf, "isEnemy ");
+                if (e->objConds & OCOND_OCCUPY_SQ)   strcat_s(cbuf, sizeof cbuf, "OccupySq ");
+                if (e->objConds & OCOND_FULL_OCC)    strcat_s(cbuf, sizeof cbuf, "FullOcc ");
+                if (e->objConds & OCOND_ENEMY_OCC)   strcat_s(cbuf, sizeof cbuf, "EnemyOcc ");
+                if (e->objConds & OCOND_BLOCK_PROJ)  strcat_s(cbuf, sizeof cbuf, "BlkProj ");
+                if (e->objConds & OCOND_NO_COVER)    strcat_s(cbuf, sizeof cbuf, "NoCover ");
+                if (e->objConds & OCOND_CONNECTS)    strcat_s(cbuf, sizeof cbuf, "Connects ");
+                if (e->objConds & OCOND_NO_WALL_RPT) strcat_s(cbuf, sizeof cbuf, "NoWallRpt ");
+                if (e->objConds & OCOND_FLYING)      strcat_s(cbuf, sizeof cbuf, "Flying ");
+                if (e->objConds & OCOND_PROT_GND)    strcat_s(cbuf, sizeof cbuf, "PrtGnd ");
+                if (e->objConds & OCOND_PROT_SINK)   strcat_s(cbuf, sizeof cbuf, "PrtSink ");
+            }
+            if (e->condLo | e->condHi) {
+                if (cbuf[0]) strcat_s(cbuf, sizeof cbuf, "| ");
+                char sbuf[256] = {};
+                RuntimeOffsets::FormatMapObjectConditionMask(e->condLo, e->condHi, sbuf, sizeof sbuf);
+                strcat_s(cbuf, sizeof cbuf, sbuf);
+            }
+            if (cbuf[0])
+                ImGui::TextColored(ImVec4(0.85f, 0.75f, 1.f, 1.f), "%s", cbuf);
+            else
+                ImGui::TextDisabled("--");
+        }
+    }
+    ImGui::EndTable();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enemy projectiles (hook ring + WM list walk merged on refresh)
+// ─────────────────────────────────────────────────────────────────────────────
+static void DrawProjectileTable(const std::vector<const WorldProjectile*>& shown)
+{
+    static constexpr ImGuiTableFlags kFlags =
+        ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+        ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable |
+        ImGuiTableFlags_SizingFixedFit;
+
+    if (!ImGui::BeginTable("ProjTable", 12, kFlags, ImGui::GetContentRegionAvail()))
+        return;
+
+    ImGui::TableSetupScrollFreeze(0, 1);
+    ImGui::TableSetupColumn("Ptr",       ImGuiTableColumnFlags_WidthFixed, 130.f);
+    ImGui::TableSetupColumn("X",         ImGuiTableColumnFlags_WidthFixed,  56.f);
+    ImGui::TableSetupColumn("Y",         ImGuiTableColumnFlags_WidthFixed,  56.f);
+    ImGui::TableSetupColumn("Bullet",    ImGuiTableColumnFlags_WidthFixed,  52.f);
+    ImGui::TableSetupColumn("Dmg",       ImGuiTableColumnFlags_WidthFixed,  72.f);
+    ImGui::TableSetupColumn("Speed",     ImGuiTableColumnFlags_WidthFixed,  64.f);
+    ImGui::TableSetupColumn("Life ms",   ImGuiTableColumnFlags_WidthFixed,  58.f);
+    ImGui::TableSetupColumn("HalfR",     ImGuiTableColumnFlags_WidthFixed,  50.f);
+    ImGui::TableSetupColumn("Attacker",  ImGuiTableColumnFlags_WidthFixed,  64.f);
+    ImGui::TableSetupColumn("Owner",     ImGuiTableColumnFlags_WidthFixed,  64.f);
+    ImGui::TableSetupColumn("Dist",      ImGuiTableColumnFlags_WidthFixed,  44.f);
+    ImGui::TableSetupColumn("Flags",     ImGuiTableColumnFlags_WidthStretch,   0.f);
+    ImGui::TableHeadersRow();
+
+    for (const WorldProjectile* p : shown) {
+        ImGui::TableNextRow();
+
+        float lx = p->x, ly = p->y;
+        if (p->ptr && AddrValid(p->ptr)) {
+            __try {
+                uint8_t* pi = reinterpret_cast<uint8_t*>(p->ptr);
+                lx = *reinterpret_cast<float*>(pi + OFF_POS_X);
+                ly = *reinterpret_cast<float*>(pi + OFF_POS_Y);
+            } __except (EXCEPTION_EXECUTE_HANDLER) {}
+        }
+
+        ImGui::TableNextColumn();
+        {
+            char ptrbuf[24];
+            snprintf(ptrbuf, sizeof(ptrbuf), "0x%llX", (unsigned long long)p->ptr);
+            ImGui::TextDisabled("%s", ptrbuf);
+            if (ImGui::IsItemClicked()) ImGui::SetClipboardText(ptrbuf);
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Click to copy address\nDouble-click: inspect fields (popup)");
+            if (p->ptr && Resolver::Protection::IsValidIl2CppObject((Il2CppObject*)p->ptr)) {
+                if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+                    s_worldInspectObj = (Il2CppObject*)p->ptr;
+                    s_worldInspectObjectId = -1;
+                    snprintf(s_worldInspectSubtitle, sizeof(s_worldInspectSubtitle),
+                        "Projectile  bulletId=%d  attackerObjId=%d  ownerObjId=%u",
+                        p->bulletId, p->attackerObjId, (unsigned)p->ownerObjId);
+                    ImGui::OpenPopupEx(s_worldInspectPopupRootId, ImGuiPopupFlags_None);
+                }
+            }
+        }
+        ImGui::TableNextColumn(); ImGui::Text("%.2f", lx);
+        ImGui::TableNextColumn(); ImGui::Text("%.2f", ly);
+        ImGui::TableNextColumn(); ImGui::Text("%d", p->bulletId);
+        ImGui::TableNextColumn();
+        if (p->minDamage > 0 && p->minDamage < p->damage)
+            ImGui::Text("%d-%d", p->minDamage, p->damage);
+        else
+            ImGui::Text("%d", p->damage);
+        ImGui::TableNextColumn(); ImGui::Text("%.0f", p->speed);
+        ImGui::TableNextColumn(); ImGui::Text("%.0f", p->lifetime);
+        ImGui::TableNextColumn(); ImGui::Text("%.3f", p->projHalfSize);
+        ImGui::TableNextColumn(); ImGui::Text("%d", p->attackerObjId);
+        ImGui::TableNextColumn(); ImGui::Text("%u", p->ownerObjId);
+        ImGui::TableNextColumn();
+        ImGui::Text("%.1f", Distance(lx, ly, g_localX, g_localY));
+
+        ImGui::TableNextColumn();
+        {
+            char fbuf[48] = {};
+            if (p->wavy)       strcat_s(fbuf, "wavy ");
+            if (p->boomerang)  strcat_s(fbuf, "boom ");
+            if (p->parametric) strcat_s(fbuf, "param ");
+            if (p->isAccelerating) strcat_s(fbuf, "accel ");
+            if (fbuf[0] == '\0') strcat_s(fbuf, "—");
+            ImGui::TextUnformatted(fbuf);
+        }
+    }
+    ImGui::EndTable();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Render
+// ─────────────────────────────────────────────────────────────────────────────
+void WorldTAB::Render()
+{
+    if (ImGuiWindow* ww = ImGui::GetCurrentWindow())
+        s_worldInspectPopupRootId = ww->GetID("WorldObjectInspect");
+
+    const float dt = ImGui::GetIO().DeltaTime;
+
+    if (g_autoRefresh) {
+        g_autoTimer -= dt;
+        if (g_autoTimer <= 0.f) { DoRefresh(); g_autoTimer = g_autoInterval; }
+    }
+
+    // ── Header bar ────────────────────────────────────────────────────────────
+    ImGui::Spacing();
+    ImGui::TextColored(ImVec4(0.4f, 1.f, 0.6f, 1.f), "WORLD ENTITIES");
+    ImGui::SameLine(0.f, 16.f);
+
+    if (ImGui::Button("Refresh")) { DoRefresh(); g_autoTimer = g_autoInterval; }
+    ImGui::SameLine();
+    ImGui::Checkbox("Auto", &g_autoRefresh);
+    if (g_autoRefresh) {
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(50.f);
+        ImGui::DragFloat("##ival", &g_autoInterval, 0.1f, 0.2f, 10.f, "%.1fs");
+    }
+    ImGui::Separator();
+
+    // ── Status ────────────────────────────────────────────────────────────────
+    {
+        ImVec4 sc = g_statusOk ? ImVec4(0.5f,0.5f,0.5f,1.f) : ImVec4(1.f,0.3f,0.3f,1.f);
+        ImGui::TextColored(sc, "%s", g_status.c_str());
+    }
+
+    // ── WorldManager info (collapsible) ───────────────────────────────────────
+    if (g_worldMgrPtr) {
+        ImGui::Spacing();
+        if (ImGui::CollapsingHeader("WorldManager Info")) {
+            ImGui::Indent(8.f);
+            ImGui::TextColored(ImVec4(0.6f,0.8f,1.f,1.f), "AppMgr   0x%llX", (unsigned long long)g_appMgrPtr);
+            ImGui::TextColored(ImVec4(0.6f,1.f,0.8f,1.f), "WorldMgr 0x%llX", (unsigned long long)g_worldMgrPtr);
+            ImGui::Spacing();
+            ImGui::TextDisabled("--- time/tick candidates ---");
+            ImGui::Text("+0xD8 Ticks = %u",   g_wm_d8);
+            ImGui::Text("+0xDC uint  = %u",   g_wm_dc);
+            ImGui::Text("+0xE0 uint  = %u",   g_wm_e0);
+            ImGui::Text("+0xF4 float = %.3f", g_wm_f4);
+            ImGui::Text("+0xF8 float = %.3f", g_wm_f8);
+            ImGui::Text("+0xFC int   = %d",   g_wm_fc);
+            ImGui::Text("+0x100 int  = %d",   g_wm_100);
+            ImGui::TextDisabled("Projectiles: WM dicts +0xB8/+0xC0, List +0x%X (HBEAKBIHANL) + SpawnProjectile hook.", OFF_WM_KJMON_LIST);
+            ImGui::Unindent(8.f);
+        }
+        ImGui::Spacing();
+    }
+
+    if (g_entities.empty() && g_tiles.empty() && g_projectiles.empty()) {
+        ImGui::TextDisabled("No data. Press Refresh while in-game.");
+        DrawWorldInspectPopupModal();
+        return;
+    }
+
+    // ── Table switcher tabs ────────────────────────────────────────────────────
+    // Count entities per category for the badge
+    // Players = FKALGHJIADI only
+    // Enemies = PMMFLLAIPGN
+    // Objects = portals, chests, statics, etc.
+    int nAll = 0, nPlayer = 0, nEnemy = 0, nObject = 0;
+    for (const WorldEntity& e : g_entities) {
+        ++nAll;
+        if (IsPlayerClass(e)) ++nPlayer;
+        else if (IsEnemy(e))  ++nEnemy;
+        else                  ++nObject;
+    }
+
+    ImGui::Spacing();
+    ImGui::Text("Local: (%.1f, %.1f)", g_localX, g_localY);
+    ImGui::Spacing();
+
+    // Primary tab bar: Objects / Tiles / Projectiles / Throwables
+    {
+        char entLabel[40], tileLabel[40], projLabel[48], aoeLabel[48];
+        snprintf(entLabel,  sizeof(entLabel),  "Objects (%d)##etab",            (int)g_entities.size());
+        snprintf(tileLabel, sizeof(tileLabel), "Tiles (%zu)##ttab",             g_tiles.size());
+        snprintf(projLabel, sizeof(projLabel), "Projectiles (%zu)##ptab",       g_projectiles.size());
+        snprintf(aoeLabel,  sizeof(aoeLabel),  "Throwables (%d)##aoetab",       AoeTracking::CountActive());
+
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10.f, 4.f));
+
+        bool entSel  = (g_activeTable == 0);
+        bool tileSel = (g_activeTable == 1);
+        bool projSel = (g_activeTable == 2);
+        bool aoeSel  = (g_activeTable == 3);
+
+        if (entSel)
+            ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_ButtonActive));
+        if (ImGui::Button(entLabel)) g_activeTable = 0;
+        if (entSel)  ImGui::PopStyleColor();
+
+        ImGui::SameLine();
+
+        if (tileSel)
+            ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_ButtonActive));
+        if (ImGui::Button(tileLabel)) g_activeTable = 1;
+        if (tileSel) ImGui::PopStyleColor();
+
+        ImGui::SameLine();
+
+        if (projSel)
+            ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_ButtonActive));
+        if (ImGui::Button(projLabel)) g_activeTable = 2;
+        if (projSel) ImGui::PopStyleColor();
+
+        ImGui::SameLine();
+
+        if (aoeSel)
+            ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_ButtonActive));
+        if (ImGui::Button(aoeLabel)) g_activeTable = 3;
+        if (aoeSel) ImGui::PopStyleColor();
+
+        ImGui::PopStyleVar();
+    }
+
+    ImGui::Separator();
+
+    // ── OBJECT VIEW ──────────────────────────────────────────────────────────
+    if (g_activeTable == 0)
+    {
+        // Category filter row (All / Players / Enemies / Objects with counts)
+        {
+            const int counts[] = { nAll, nPlayer, nEnemy, nObject };
+            const ImVec4 cols[] = {
+                ImVec4(0.8f, 0.8f, 0.8f, 1.f),   // All — white-ish
+                ImVec4(0.3f, 0.6f, 1.0f, 1.f),   // Players — blue
+                ImVec4(1.0f, 0.35f, 0.25f, 1.f), // Enemies — red-orange
+                ImVec4(0.8f, 0.65f, 0.2f, 1.f),  // Objects — gold
+            };
+
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.f, 3.f));
+            for (int ci = 0; ci < 4; ++ci) {
+                if (ci > 0) ImGui::SameLine();
+                char lbl[32];
+                snprintf(lbl, sizeof(lbl), "%s (%d)##cat%d", kCatLabels[ci], counts[ci], ci);
+
+                bool selected = (g_entityCat == (EntityCat)ci);
+                if (selected) {
+                    ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetColorU32(ImGuiCol_ButtonActive));
+                    ImGui::PushStyleColor(ImGuiCol_Text, cols[ci]);
+                }
+                if (ImGui::Button(lbl)) g_entityCat = (EntityCat)ci;
+                if (selected) ImGui::PopStyleColor(2);
+            }
+            ImGui::PopStyleVar();
+        }
+
+        ImGui::SameLine(0.f, 16.f);
+        ImGui::SetNextItemWidth(160.f);
+        ImGui::InputTextWithHint("##eflt", "Filter id / class / type / name / Static...", g_filter, sizeof(g_filter));
+
+        ImGui::Spacing();
+
+        // Build filtered + sorted list
+        std::vector<const WorldEntity*> shown;
+        shown.reserve(g_entities.size());
+        for (const WorldEntity& e : g_entities) {
+            if (!MatchesCat(e, g_entityCat)) continue;
+            if (g_filter[0]) {
+                char idBuf[32], typBuf[32], condBuf[384] = {};
+                snprintf(idBuf, sizeof(idBuf), "%d", e.objectId);
+                snprintf(typBuf, sizeof(typBuf), "0x%X", (uint32_t)e.objType);
+                if (e.objConds & OCOND_STATIC)      strcat_s(condBuf, sizeof condBuf, "Static ");
+                if (e.objConds & OCOND_IS_ENEMY)    strcat_s(condBuf, sizeof condBuf, "isEnemy ");
+                if (e.objConds & OCOND_OCCUPY_SQ)   strcat_s(condBuf, sizeof condBuf, "OccupySq ");
+                if (e.objConds & OCOND_FULL_OCC)    strcat_s(condBuf, sizeof condBuf, "FullOcc ");
+                if (e.objConds & OCOND_ENEMY_OCC)   strcat_s(condBuf, sizeof condBuf, "EnemyOcc ");
+                if (e.objConds & OCOND_BLOCK_PROJ)  strcat_s(condBuf, sizeof condBuf, "BlkProj ");
+                if (e.objConds & OCOND_NO_COVER)    strcat_s(condBuf, sizeof condBuf, "NoCover ");
+                if (e.objConds & OCOND_CONNECTS)    strcat_s(condBuf, sizeof condBuf, "Connects ");
+                if (e.objConds & OCOND_FLYING)      strcat_s(condBuf, sizeof condBuf, "Flying ");
+                if (e.condLo | e.condHi) {
+                    char mbuf[256] = {};
+                    RuntimeOffsets::FormatMapObjectConditionMask(e.condLo, e.condHi, mbuf, sizeof mbuf);
+                    strcat_s(condBuf, sizeof condBuf, mbuf);
+                }
+                if (!strstr(idBuf,        g_filter) &&
+                    !strstr(e.typeName,   g_filter) &&
+                    !strstr(typBuf,       g_filter) &&
+                    !strstr(e.objName,    g_filter) &&
+                    !strstr(e.playerName, g_filter) &&
+                    !strstr(condBuf,      g_filter)) continue;
+            }
+            shown.push_back(&e);
+        }
+
+        // Sort: local first, then by distance
+        std::sort(shown.begin(), shown.end(), [](const WorldEntity* a, const WorldEntity* b) {
+            if (a->isLocal != b->isLocal) return a->isLocal > b->isLocal;
+            return Distance(a->x, a->y, g_localX, g_localY) <
+                   Distance(b->x, b->y, g_localX, g_localY);
+        });
+
+        ImGui::TextDisabled("Showing %zu / %zu", shown.size(), g_entities.size());
+        ImGui::Spacing();
+        DrawEntityTable(shown);
+    }
+    // ── PROJECTILES VIEW ─────────────────────────────────────────────────────
+    else if (g_activeTable == 2)
+    {
+        ImGui::TextDisabled("Refresh merges hook + WM KJMONHENJEN dicts (0xB8/0xC0) and list (+0xE8). Shooter IDs use entity scan + dict key.");
+        ImGui::Spacing();
+        ImGui::SetNextItemWidth(220.f);
+        ImGui::InputTextWithHint("##pflt", "Filter ptr / bullet / id / flags...", g_projFilter, sizeof(g_projFilter));
+
+        ImGui::Spacing();
+
+        std::vector<const WorldProjectile*> shown;
+        shown.reserve(g_projectiles.size());
+        for (const WorldProjectile& p : g_projectiles) {
+            if (!p.valid) continue;
+            if (g_projFilter[0]) {
+                char ptrbuf[32], bid[24], atk[24], own[24], fl[48] = {};
+                snprintf(ptrbuf, sizeof(ptrbuf), "%llX", (unsigned long long)p.ptr);
+                snprintf(bid, sizeof(bid), "%d", p.bulletId);
+                snprintf(atk, sizeof(atk), "%d", p.attackerObjId);
+                snprintf(own, sizeof(own), "%u", p.ownerObjId);
+                if (p.wavy) strcat_s(fl, "wavy ");
+                if (p.boomerang) strcat_s(fl, "boom ");
+                if (p.parametric) strcat_s(fl, "param ");
+                if (p.isAccelerating) strcat_s(fl, "accel ");
+                if (!strstr(ptrbuf, g_projFilter) && !strstr(bid, g_projFilter) &&
+                    !strstr(atk, g_projFilter) && !strstr(own, g_projFilter) &&
+                    !strstr(fl, g_projFilter))
+                    continue;
+            }
+            shown.push_back(&p);
+        }
+
+        std::sort(shown.begin(), shown.end(), [](const WorldProjectile* a, const WorldProjectile* b) {
+            return Distance(a->x, a->y, g_localX, g_localY) < Distance(b->x, b->y, g_localX, g_localY);
+        });
+
+        ImGui::TextDisabled("Showing %zu / %zu", shown.size(), g_projectiles.size());
+        ImGui::Spacing();
+        DrawProjectileTable(shown);
+    }
+    // ── THROWABLES / AOE VIEW ────────────────────────────────────────────────
+    else if (g_activeTable == 3)
+    {
+        AoeTracking::EnsureInstalled();
+        ImGui::TextDisabled(
+            "Four hook paths: GJJ=GJJCEFJMNMK entity  FHOH=visual fallback  EXPL=explosion controller  SFX=ShowEffect packet.");
+        ImGui::TextDisabled(
+            "GJJ/FHOH radius = 2.0 default. EXPL radius = CustomExplosionEntrance+0x38 (~3.0 tiles). "
+            "SFX OwnerID = packet targetObjectId (direct source entity). GJJ/FHOH OwnerID = throwable object (not thrower).");
+        ImGui::Spacing();
+
+        std::vector<WorldAoe> aoes;
+        AoeTracking::CopyActiveForDraw(aoes);
+
+        const ULONGLONG now = GetTickCount64();
+
+        static constexpr ImGuiTableFlags kAoeFlags =
+            ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+            ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable |
+            ImGuiTableFlags_SizingFixedFit;
+
+        // Count breakdown
+        int nDamaging = 0, nEnemy = 0, nFriendly = 0;
+        for (const WorldAoe& a : aoes) {
+            if (a.isDamaging) { ++nDamaging; if (a.isEnemy) ++nEnemy; else ++nFriendly; }
+        }
+        ImGui::TextDisabled("Active: %d  |  Damaging: %d  (Enemy: %d  Friendly: %d)  |  Hooks: %d",
+            (int)aoes.size(), nDamaging, nEnemy, nFriendly, AoeTracking::CountHooks());
+        ImGui::Spacing();
+
+        if (ImGui::BeginTable("AoeTable", 13, kAoeFlags, ImGui::GetContentRegionAvail())) {
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableSetupColumn("Src",       ImGuiTableColumnFlags_WidthFixed,  42.f);
+            ImGui::TableSetupColumn("Side",      ImGuiTableColumnFlags_WidthFixed,  68.f);
+            ImGui::TableSetupColumn("OwnerID",   ImGuiTableColumnFlags_WidthFixed,  72.f);
+            ImGui::TableSetupColumn("Dmg",       ImGuiTableColumnFlags_WidthFixed,  38.f);
+            ImGui::TableSetupColumn("DestX",     ImGuiTableColumnFlags_WidthFixed,  62.f);
+            ImGui::TableSetupColumn("DestY",     ImGuiTableColumnFlags_WidthFixed,  62.f);
+            ImGui::TableSetupColumn("OriginX",   ImGuiTableColumnFlags_WidthFixed,  62.f);
+            ImGui::TableSetupColumn("OriginY",   ImGuiTableColumnFlags_WidthFixed,  62.f);
+            ImGui::TableSetupColumn("Radius",    ImGuiTableColumnFlags_WidthFixed,  52.f);
+            ImGui::TableSetupColumn("Dur ms",    ImGuiTableColumnFlags_WidthFixed,  54.f);
+            ImGui::TableSetupColumn("Rem ms",    ImGuiTableColumnFlags_WidthFixed,  54.f);
+            ImGui::TableSetupColumn("Ptr",       ImGuiTableColumnFlags_WidthFixed, 130.f);
+            ImGui::TableSetupColumn("SFX Type",  ImGuiTableColumnFlags_WidthStretch,  0.f);
+            ImGui::TableHeadersRow();
+
+            for (const WorldAoe& a : aoes) {
+                float elapsed = static_cast<float>(now - a.spawnTick);
+                if (elapsed >= a.lifetime) continue;
+                float remMs = a.lifetime - elapsed;
+
+                // Row tint: enemy red, friendly green, unresolved side yellow, expiring orange
+                if (a.isDamaging && a.isEnemyChecked && a.isEnemy)
+                    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                        ImGui::GetColorU32(ImVec4(0.45f, 0.04f, 0.04f, 0.55f)));
+                else if (a.isDamaging && a.isEnemyChecked && !a.isEnemy)
+                    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                        ImGui::GetColorU32(ImVec4(0.04f, 0.30f, 0.06f, 0.45f)));
+                else if (a.isDamaging && !a.isEnemyChecked)
+                    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                        ImGui::GetColorU32(ImVec4(0.30f, 0.25f, 0.04f, 0.45f)));
+                else if (remMs < 500.f)
+                    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                        ImGui::GetColorU32(ImVec4(0.35f, 0.15f, 0.0f, 0.45f)));
+
+                ImGui::TableNextRow();
+
+                // Source path
+                ImGui::TableNextColumn();
+                switch (a.source) {
+                case kAoeSrcGjj:  ImGui::TextColored(ImVec4(1.0f, 0.55f, 0.10f, 1.f), "GJJ");  break;
+                case kAoeSrcFhoh: ImGui::TextColored(ImVec4(1.0f, 0.85f, 0.20f, 1.f), "FHOH"); break;
+                case kAoeSrcExpl: ImGui::TextColored(ImVec4(0.4f, 0.85f, 1.00f, 1.f), "EXPL"); break;
+                case kAoeSrcSfx:  ImGui::TextColored(ImVec4(0.5f, 1.00f, 0.55f, 1.f), "SFX");  break;
+                default:          ImGui::TextDisabled("?");                                      break;
+                }
+
+                // Side: Enemy / Friendly / pending (yellow) / unknown
+                ImGui::TableNextColumn();
+                if (!a.isDamaging) {
+                    ImGui::TextDisabled("?");
+                } else if (!a.isEnemyChecked) {
+                    ImGui::TextColored(ImVec4(1.f, 0.85f, 0.1f, 1.f), "pending");
+                } else if (a.isEnemy) {
+                    ImGui::TextColored(ImVec4(1.f, 0.25f, 0.25f, 1.f), "Enemy");
+                } else {
+                    ImGui::TextColored(ImVec4(0.3f, 1.f, 0.4f, 1.f), "Friendly");
+                }
+
+                // OwnerID — meaning depends on source:
+                //   GJJ/FHOH: throwable object's objectId (NOT the thrower)
+                //   EXPL:     anchor (thrower) entity objectId
+                //   SFX:      packet targetObjectId = source entity (thrower/caster)
+                ImGui::TableNextColumn();
+                if (a.ownerObjId != 0) {
+                    if (a.source == kAoeSrcExpl || a.source == kAoeSrcSfx)
+                        ImGui::Text("%d", a.ownerObjId);       // direct thrower/source entity
+                    else
+                        ImGui::TextDisabled("%d", a.ownerObjId); // throwable object (not thrower)
+                } else {
+                    ImGui::TextDisabled("--");
+                }
+                if (ImGui::IsItemHovered()) {
+                    const char* tip = (a.source == kAoeSrcExpl) ? "Anchor (thrower) entity objectId"
+                                    : (a.source == kAoeSrcSfx)  ? "ShowEffect targetObjectId — source entity"
+                                    : "Throwable/visual object objectId (not the thrower)";
+                    ImGui::SetTooltip("%s", tip);
+                }
+
+                // Damaging?
+                ImGui::TableNextColumn();
+                if (a.isDamaging)
+                    ImGui::TextColored(ImVec4(1.f, 0.3f, 0.2f, 1.f), "YES");
+                else
+                    ImGui::TextDisabled("no");
+
+                // Destination (landing spot / effect centre)
+                ImGui::TableNextColumn(); ImGui::Text("%.2f", a.destX);
+                ImGui::TableNextColumn(); ImGui::Text("%.2f", a.destY);
+
+                // Origin (throw source / SFX pos1)
+                ImGui::TableNextColumn(); ImGui::TextDisabled("%.2f", a.x);
+                ImGui::TableNextColumn(); ImGui::TextDisabled("%.2f", a.y);
+
+                // Radius
+                ImGui::TableNextColumn();
+                if (a.isDamaging)
+                    ImGui::Text("%.2f", a.radius);
+                else
+                    ImGui::TextDisabled("~%.2f", a.radius);
+
+                // Total duration ms
+                ImGui::TableNextColumn();
+                ImGui::Text("%.0f", a.lifetime);
+
+                // Remaining ms
+                ImGui::TableNextColumn();
+                if (remMs < 500.f)
+                    ImGui::TextColored(ImVec4(1.f, 0.3f, 0.2f, 1.f), "%.0f", remMs);
+                else
+                    ImGui::Text("%.0f", remMs);
+
+                // Live ptr (moved to end as less important)
+                ImGui::TableNextColumn();
+                if (a.ptr)
+                    ImGui::Text("0x%llX", (unsigned long long)a.ptr);
+                else
+                    ImGui::TextDisabled("--");
+
+                // SFX effect type — only populated for kAoeSrcSfx entries
+                ImGui::TableNextColumn();
+                if (a.source == kAoeSrcSfx) {
+                    switch (a.sfxEffectType) {
+                    case  4: ImGui::TextColored(ImVec4(0.5f, 1.f, 0.55f, 1.f), "THROW(4)");   break;
+                    case  5: ImGui::TextColored(ImVec4(0.5f, 1.f, 0.55f, 1.f), "NOVA(5)");    break;
+                    case 23: ImGui::TextColored(ImVec4(0.5f, 1.f, 0.55f, 1.f), "CIRC(23)");   break;
+                    case 39: ImGui::TextColored(ImVec4(0.5f, 1.f, 0.55f, 1.f), "AOE(39)");    break;
+                    default: ImGui::TextColored(ImVec4(0.5f, 1.f, 0.55f, 1.f), "SFX(%d)", a.sfxEffectType); break;
+                    }
+                } else {
+                    ImGui::TextDisabled("--");
+                }
+            }
+            ImGui::EndTable();
+        }
+    }
+    // ── TILE VIEW ─────────────────────────────────────────────────────────────
+    else
+    {
+        ImGui::SetNextItemWidth(240.f);
+        ImGui::InputTextWithHint("##tflt", "Filter type / x / y / name / Sink / Push...", g_tileFilter, sizeof(g_tileFilter));
+
+        ImGui::Spacing();
+
+        std::vector<const WorldTile*> shown;
+        shown.reserve(g_tiles.size());
+        for (const WorldTile& t : g_tiles) {
+            if (g_tileFilter[0]) {
+                char xbuf[16], ybuf[16], typbuf[16];
+                snprintf(xbuf,   sizeof(xbuf),   "%d",   t.tileX);
+                snprintf(ybuf,   sizeof(ybuf),   "%d",   t.tileY);
+                snprintf(typbuf, sizeof(typbuf), "0x%X", (uint32_t)t.tileType);
+                // Build condition string for matching
+                char condbuf[64] = {};
+                if (t.conds & TCOND_SINK)    strcat_s(condbuf, "Sink ");
+                if (t.conds & TCOND_SINKING) strcat_s(condbuf, "Sinking ");
+                if (t.conds & TCOND_PUSH)    strcat_s(condbuf, "Push ");
+                if (t.conds & TCOND_ALPHA)   strcat_s(condbuf, "Alpha ");
+                if (t.conds & TCOND_NOWALK)  strcat_s(condbuf, "NoWalk");
+                if (!strstr(xbuf,         g_tileFilter) &&
+                    !strstr(ybuf,         g_tileFilter) &&
+                    !strstr(typbuf,       g_tileFilter) &&
+                    !strstr(condbuf,      g_tileFilter) &&
+                    !strstr(t.tileName,   g_tileFilter)) continue;
+            }
+            shown.push_back(&t);
+        }
+
+        // Sort by distance from local player (closest first)
+        std::sort(shown.begin(), shown.end(), [](const WorldTile* a, const WorldTile* b) {
+            auto dx = [](int32_t tx, float lx){ return (float)tx - lx; };
+            auto dy = [](int32_t ty, float ly){ return (float)ty - ly; };
+            float da = dx(a->tileX,g_localX)*dx(a->tileX,g_localX) + dy(a->tileY,g_localY)*dy(a->tileY,g_localY);
+            float db = dx(b->tileX,g_localX)*dx(b->tileX,g_localX) + dy(b->tileY,g_localY)*dy(b->tileY,g_localY);
+            return da < db;
+        });
+
+        ImGui::TextDisabled("Showing %zu / %zu", shown.size(), g_tiles.size());
+        ImGui::Spacing();
+
+        static constexpr ImGuiTableFlags kFlags =
+            ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+            ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable |
+            ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingFixedFit;
+
+        if (ImGui::BeginTable("TileTable", 8, kFlags, ImGui::GetContentRegionAvail())) {
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableSetupColumn("Type",   ImGuiTableColumnFlags_WidthFixed,  70.f);
+            ImGui::TableSetupColumn("X",      ImGuiTableColumnFlags_WidthFixed,  55.f);
+            ImGui::TableSetupColumn("Y",      ImGuiTableColumnFlags_WidthFixed,  55.f);
+            ImGui::TableSetupColumn("Damage", ImGuiTableColumnFlags_WidthFixed,  90.f);
+            ImGui::TableSetupColumn("Speed",  ImGuiTableColumnFlags_WidthFixed,  60.f);
+            ImGui::TableSetupColumn("Dist",   ImGuiTableColumnFlags_WidthFixed,  50.f);
+            ImGui::TableSetupColumn("Conds",  ImGuiTableColumnFlags_WidthFixed, 130.f);
+            ImGui::TableSetupColumn("Name",   ImGuiTableColumnFlags_WidthStretch,  0.f);
+            ImGui::TableHeadersRow();
+
+            for (const WorldTile* t : shown) {
+                // Tint hazardous tiles
+                bool hasDmg   = (t->minDmg > 0 || t->maxDmg > 0);
+                bool hasSink  = (t->conds & TCOND_SINK) || (t->conds & TCOND_SINKING);
+                bool hasPush  = (t->conds & TCOND_PUSH) != 0;
+                if (hasDmg || hasSink)
+                    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                        ImGui::GetColorU32(ImVec4(0.4f, 0.1f, 0.0f, 0.45f)));
+                else if (hasPush)
+                    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
+                        ImGui::GetColorU32(ImVec4(0.0f, 0.2f, 0.4f, 0.45f)));
+
+                ImGui::TableNextRow();
+                // Type (hex)
+                ImGui::TableNextColumn();
+                ImGui::Text("0x%X", (uint32_t)t->tileType);
+                // X / Y
+                ImGui::TableNextColumn(); ImGui::Text("%d", t->tileX);
+                ImGui::TableNextColumn(); ImGui::Text("%d", t->tileY);
+                // Damage: "60" or "40-80" or "—"
+                ImGui::TableNextColumn();
+                if (hasDmg) {
+                    if (t->minDmg == t->maxDmg)
+                        ImGui::TextColored(ImVec4(1.f,0.4f,0.3f,1.f), "%d", t->minDmg);
+                    else
+                        ImGui::TextColored(ImVec4(1.f,0.4f,0.3f,1.f), "%d-%d", t->minDmg, t->maxDmg);
+                } else {
+                    ImGui::TextDisabled("—");
+                }
+                // Speed
+                ImGui::TableNextColumn();
+                if (t->speed > 0.001f && t->speed < 0.9999f)
+                    ImGui::TextColored(ImVec4(1.f,0.85f,0.2f,1.f), "%.0f%%", t->speed * 100.f);
+                else
+                    ImGui::TextDisabled("—");
+                // Distance from player
+                ImGui::TableNextColumn();
+                {
+                    float dx = (float)t->tileX - g_localX;
+                    float dy = (float)t->tileY - g_localY;
+                    float dist = std::sqrt(dx*dx + dy*dy);
+                    ImGui::Text("%.0f", dist);
+                }
+                // Conditions string
+                ImGui::TableNextColumn();
+                {
+                    char cbuf[64] = {};
+                    if (t->conds & TCOND_SINK)    strcat_s(cbuf, "Sink ");
+                    if (t->conds & TCOND_SINKING) strcat_s(cbuf, "Sinking ");
+                    if (t->conds & TCOND_PUSH)    strcat_s(cbuf, "Push ");
+                    if (t->conds & TCOND_ALPHA)   strcat_s(cbuf, "Alpha ");
+                    if (t->conds & TCOND_NOWALK)  strcat_s(cbuf, "NoWalk");
+                    if (cbuf[0])
+                        ImGui::TextColored(ImVec4(0.7f,0.9f,1.f,1.f), "%s", cbuf);
+                    else
+                        ImGui::TextDisabled("—");
+                }
+                // Name — XML id from ObjectProperties
+                ImGui::TableNextColumn();
+                if (t->tileName[0]) ImGui::TextUnformatted(t->tileName);
+                else                ImGui::TextDisabled("--");
+            }
+            ImGui::EndTable();
+        }
+    }
+
+    DrawWorldInspectPopupModal();
+}
+
+// ── ReadMapName helpers ───────────────────────────────────────────────────────
+// Safe approach: reads the IL2CPP managed string pointer at wm+fieldOffset,
+// then copies wchar_t chars as ASCII. Only POD types — __try is valid.
+static bool SehReadStringField(void* wm, uint32_t fieldOffset, char* buf, int bufLen)
+{
+    void* strPtr = nullptr;
+    __try { strPtr = *reinterpret_cast<void**>((uint8_t*)wm + fieldOffset); }
+    __except(EXCEPTION_EXECUTE_HANDLER) { return false; }
+    if (!strPtr) return false;
+
+    int32_t len = 0;
+    __try { len = *reinterpret_cast<int32_t*>((uint8_t*)strPtr + 0x10); }
+    __except(EXCEPTION_EXECUTE_HANDLER) { return false; }
+    if (len <= 0 || len > 64) return false;
+
+    int copyLen = (len < bufLen - 1) ? len : bufLen - 1;
+    __try {
+        const wchar_t* chars = reinterpret_cast<const wchar_t*>((uint8_t*)strPtr + 0x14);
+        for (int i = 0; i < copyLen; i++)
+            buf[i] = (chars[i] >= 0x20 && chars[i] < 0x7F) ? (char)chars[i] : '\0';
+        buf[copyLen] = '\0';
+    } __except(EXCEPTION_EXECUTE_HANDLER) { buf[0] = '\0'; return false; }
+
+    for (int i = 0; i < copyLen; i++)
+        if (buf[i] == '\0') { buf[0] = '\0'; return false; }
+
+    return true;
+}
+
+// Probes known HJMBOMEHGDJ (WorldManager) string fields in order:
+//   0x1E0 = AINOLPMCJIK (public), 0x1C0 = OEHNFKAGPDD, 0x108 = PICNEHLAODO
+static bool SehCallAndReadMapString(void* wm, uintptr_t /*base*/, char* buf, int bufLen)
+{
+    static const uint32_t kOffsets[] = { 0x1E0, 0x1C0, 0x108 };
+
+    for (int i = 0; i < 3; i++) {
+        char tmp[128] = {};
+        bool ok = SehReadStringField(wm, kOffsets[i], tmp, sizeof(tmp));
+
+        if (ok && tmp[0]) {
+            int copyN = (static_cast<int>(strlen(tmp)) < bufLen - 1)
+                        ? static_cast<int>(strlen(tmp)) : bufLen - 1;
+            memcpy(buf, tmp, copyN);
+            buf[copyN] = '\0';
+            return true;
+        }
+    }
+    return false;
+}
+
+// ResolveLiveLocalPtr() removed — GameState::Tick() handles this every frame.
+
+// ── Public API ───────────────────────────────────────────────────────────────
+namespace WorldTAB {
+    void      ForceRefresh()
+    {
+        // Coalesce refreshes requested within the same ~50 ms window. Multiple
+        // callers (TestTAB + DebugTAB + tab Render paths) all drive this at
+        // ~100 ms cadence via independent timers; without the gate, when two
+        // happen to align in the same frame we walk the 4096-slot entity
+        // dict and the tile list twice back-to-back. 50 ms is well below the
+        // 100 ms call cadence (so legitimate ticks never get skipped) but
+        // covers frame-aligned double-calls.
+        static ULONGLONG s_lastRefreshMs = 0;
+        const ULONGLONG nowMs = GetTickCount64();
+        if (nowMs - s_lastRefreshMs < 50ULL) return;
+        s_lastRefreshMs = nowMs;
+        DoRefresh();
+    }
+    void*     GetLocalPtr()
+    {
+        // GameState owns the realtime pointer; LocalPlayer mirrors it.
+        void* lp = GameState::GetLocalPtr();
+        if (lp) { g_localPtr = lp; return lp; }
+        return g_localPtr;  // last known value from most recent DoRefresh
+    }
+    float     GetLocalX()      { return LocalPlayer::GetX() ? LocalPlayer::GetX() : g_localX; }
+    float     GetLocalY()      { return LocalPlayer::GetY() ? LocalPlayer::GetY() : g_localY; }
+    uintptr_t GetAppMgrPtr()
+    {
+        return reinterpret_cast<uintptr_t>(GameState::GetAppMgr());
+    }
+
+    void ReadLocalWorldXYLive(float& outX, float& outY)
+    {
+        // LocalPlayer::Tick() always reads XY when ptr is valid — use cache.
+        float cx = LocalPlayer::GetX(), cy = LocalPlayer::GetY();
+        if (cx != 0.f || cy != 0.f) {
+            outX = cx; outY = cy;
+            g_localX = cx; g_localY = cy;
+            return;
+        }
+        outX = g_localX;
+        outY = g_localY;
+    }
+
+    bool GetEntityLivePos(int32_t objectId, float& outX, float& outY)
+    {
+        for (const WorldEntity& e : g_entities) {
+            if (e.objectId != objectId) continue;
+            if (!AddrValid(e.ptr)) return false;
+            float lx = 0.f, ly = 0.f;
+            bool ok = SafeRead(e.ptr, OFF_POS_X, lx) && SafeRead(e.ptr, OFF_POS_Y, ly);
+            if (ok) { outX = lx; outY = ly; return true; }
+            return false;
+        }
+        return false;
+    }
+
+    // Find a player entity (FKALGHJIADI) whose IGN best matches the given query.
+    // Matching priority: exact > starts-with > contains (all case-insensitive).
+    // Among ties at the same priority, the shorter name wins (avoids picking an unrelated
+    // long name when a short partial query could match multiple players).
+    // Returns true and fills outObjectId / outMatchedName on success.
+    bool FindPlayerByName(const char* query, int32_t& outObjectId, char* outMatchedName, int nameLen)
+    {
+        if (!query || query[0] == '\0') return false;
+
+        // Build lower-case query
+        char lq[32] = {};
+        for (int i = 0; query[i] && i < 31; ++i)
+            lq[i] = (char)tolower((unsigned char)query[i]);
+
+        // Priority: 0=exact, 1=starts-with, 2=contains, 3=none
+        int   bestPri  = 3;
+        int   bestLen  = INT_MAX;
+        int32_t bestId = 0;
+        const char* bestName = nullptr;
+
+        for (const WorldEntity& e : g_entities) {
+            if (e.playerName[0] == '\0') continue;  // not a player with a known IGN
+
+            char ln[32] = {};
+            for (int i = 0; e.playerName[i] && i < 31; ++i)
+                ln[i] = (char)tolower((unsigned char)e.playerName[i]);
+
+            int elen = (int)strlen(ln);
+            int qlen = (int)strlen(lq);
+
+            int pri = 3;
+            if (strcmp(ln, lq) == 0)          pri = 0;  // exact
+            else if (strncmp(ln, lq, qlen) == 0) pri = 1;  // starts-with
+            else if (strstr(ln, lq) != nullptr)  pri = 2;  // contains
+
+            if (pri < bestPri || (pri == bestPri && elen < bestLen)) {
+                bestPri  = pri;
+                bestLen  = elen;
+                bestId   = e.objectId;
+                bestName = e.playerName;
+            }
+        }
+
+        if (bestPri == 3 || bestId == 0) return false;
+
+        outObjectId = bestId;
+        if (outMatchedName && nameLen > 0)
+            strncpy_s(outMatchedName, nameLen, bestName, nameLen - 1);
+        return true;
+    }
+
+    const std::vector<WorldEntity>& GetEntities()
+    {
+        return g_entities;
+    }
+
+    const std::vector<WorldTile>& GetTiles()
+    {
+        return g_tiles;
+    }
+
+    const std::vector<WorldProjectile>& GetProjectiles()
+    {
+        return g_projectiles;
+    }
+
+    bool IsTileBlocked(int tx, int ty)
+    {
+        std::lock_guard<std::mutex> lock(s_tileMapMutex);
+        return s_blockedMap.count(BlockedKey(tx, ty)) != 0;
+    }
+
+    bool IsTileFullOccupied(int tx, int ty)
+    {
+        std::lock_guard<std::mutex> lock(s_tileMapMutex);
+        return s_fullOccupyMap.count(BlockedKey(tx, ty)) != 0;
+    }
+
+    bool IsDamagingTile(int tx, int ty)
+    {
+        std::lock_guard<std::mutex> lock(s_tileMapMutex);
+        return s_damagingMap.count(BlockedKey(tx, ty)) != 0;
+    }
+
+    // Returns the XML speed multiplier for the tile at (tx, ty).
+    // 0.0 = no modifier; > 1.0 = speedy ground; < 1.0 = slow ground.
+    float GetTileSpeed(int tx, int ty)
+    {
+        std::lock_guard<std::mutex> lock(s_tileMapMutex);
+        auto it = s_tileSpeedMap.find(BlockedKey(tx, ty));
+        return (it != s_tileSpeedMap.end()) ? it->second : 0.f;
+    }
+
+    bool ReadMapName(char* buf, int bufLen)
+    {
+        if (!buf || bufLen <= 1) { if (buf && bufLen > 0) buf[0] = '\0'; return false; }
+        buf[0] = '\0';
+        void* wm = reinterpret_cast<void*>(g_worldMgrPtr);
+        if (!wm) return false;
+        return SehCallAndReadMapString(wm, 0, buf, bufLen);
+    }
+}

--- a/internal/src/gui/tabs/WorldTAB.h
+++ b/internal/src/gui/tabs/WorldTAB.h
@@ -1,0 +1,261 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorldEntity — snapshot of one entity from the entity dictionary.
+// Exposed here so DebugTAB can iterate the last-refreshed entity list for
+// world-space label rendering without duplicating the data.
+// ─────────────────────────────────────────────────────────────────────────────
+struct WorldEntity
+{
+    int32_t  objectId      = 0;
+    int32_t  objType       = 0;    // HFDNHJFNEKA @ 0x30 (no ACTK shift)
+    float    x             = 0.f;
+    float    y             = 0.f;
+    int32_t  hp            = 0;
+    int32_t  maxHp         = 0;
+    bool     isLocal       = false;
+    void*    ptr           = nullptr;
+    void*    klass         = nullptr;
+    char     typeName[32]  = {};
+    char     playerName[32]= {};   // DPGEBOCBKEF @ 0x178 (no ACTK shift — confirmed)
+    char     objName[64]   = {};   // ObjectProperties.id via KJMONHENJEN.OBAKMCCDBJA[0x18]+0x38
+    uint16_t objConds      = 0;    // bitmask of OCOND_* flags
+    uint32_t condLo        = 0;    // MapObject.conditions[0] (status bitmask low)
+    uint32_t condHi        = 0;    // MapObject.conditions[1] (status bitmask high)
+};
+
+// Visual-only radius used to draw OccupySquare debug circles in the overlay.
+// Flash isWalkable() has NO sub-tile circle model for OccupySquare — the entire
+// tile cell is blocked for entry.  Do not use this for collision logic.
+static constexpr float kOccupyRadius = 0.375f;  // debug visual only
+
+// Object condition bitmask flags (ObjectProperties boolean fields)
+static constexpr uint16_t OCOND_OCCUPY_SQ   = 0x0001;
+static constexpr uint16_t OCOND_FULL_OCC    = 0x0002;
+static constexpr uint16_t OCOND_ENEMY_OCC   = 0x0004;
+static constexpr uint16_t OCOND_STATIC      = 0x0008;
+static constexpr uint16_t OCOND_BLOCK_PROJ  = 0x0010;
+static constexpr uint16_t OCOND_FLYING      = 0x0020;
+static constexpr uint16_t OCOND_PROT_GND    = 0x0040;
+static constexpr uint16_t OCOND_PROT_SINK   = 0x0080;
+static constexpr uint16_t OCOND_NO_COVER    = 0x0100;
+static constexpr uint16_t OCOND_NO_WALL_RPT = 0x0200;
+static constexpr uint16_t OCOND_CONNECTS    = 0x0400;
+static constexpr uint16_t OCOND_IS_ENEMY    = 0x0800;  // ObjectProperties.isEnemy (XML Enemy element / type)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorldTile — snapshot of one ground tile from the spatial grid.
+// ─────────────────────────────────────────────────────────────────────────────
+struct WorldTile
+{
+    uint16_t tileType = 0;    // JOFEAFJPJEM @ 0x40
+    int32_t  tileX    = 0;    // grid X
+    int32_t  tileY    = 0;    // grid Y
+    int32_t  minDmg   = 0;
+    int32_t  maxDmg   = 0;
+    float    speed    = 0.f;
+    uint8_t  conds    = 0;    // bitmask of TCOND_* flags below
+    void*    ptr      = nullptr;
+    char     tileName[64] = {};
+};
+
+// Tile condition bitmask flags
+static constexpr uint8_t TCOND_SINK    = 0x01;
+static constexpr uint8_t TCOND_PUSH    = 0x02;
+static constexpr uint8_t TCOND_ALPHA   = 0x04;
+static constexpr uint8_t TCOND_SINKING = 0x08;
+static constexpr uint8_t TCOND_NOWALK  = 0x10;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorldProjectile — SpawnProjectile hook + WorldManager KJMONHENJEN containers (DIA4A offsets).
+// Filled from ProjectileTracking::SnapshotToWorld and WM dict/list merge on each refresh.
+// ─────────────────────────────────────────────────────────────────────────────
+static constexpr int kWorldProjectilePathSampleCap = 24;
+
+struct WorldProjectile
+{
+    void*    ptr            = nullptr;
+    float    x              = 0.f;  // last snapshotted world X (live read in table optional)
+    float    y              = 0.f;
+    float    startX         = 0.f;
+    float    startY         = 0.f;
+    float    angle          = 0.f;
+    float    speed          = 0.f;   // raw int as float; divide by 10000 for tiles/ms
+    float    lifetime       = 0.f;   // ms (ProjectileProperties: seconds normalized via NormalizeProjectileLifetimeMs)
+    int32_t  minDamage      = 0;
+    int32_t  damage         = 0;   // max damage (ProjectileMaxDamage @ 0x1A8)
+    bool     armorPiercing  = false;
+    int32_t  bulletId       = 0;
+    /// Runtime Chebyshev half-edge T from live HBEAKBIHANL+0x1D4 (Exalt IsHit). 0 = unread / use projHalfSize.
+    float    runtimeChebyshevHalf = 0.f;
+    /// Heuristic half-extent when runtime T unavailable (spawn-time skin/scale/magnitude).
+    float    projHalfSize   = 0.f;
+    float    amplitude      = 0.f;
+    float    frequency      = 0.f;
+    /// Flash ProjectileProperties.magnitude_ — parametric path radius (tiles), not sine amplitude.
+    float    magnitude      = 0.f;
+    /// Native KDAJOMOFMJB × optional UI scale; applied to speed/10000 distance term (ProjPosAt).
+    float    speedMul       = 1.f;
+    bool     wavy              = false;
+    bool     hasCustomAmplitude = false;  // PP+0x1A0: wavy uses Amplitude/Frequency fields instead of hardcoded π/64
+    bool     parametric     = false;
+    bool     boomerang      = false;
+    bool     isAccelerating = false;
+    /// ProjectileProperties.UseAcceleration (+0x185) — the per-shot enable flag.
+    /// Game applies acceleration only when (isAccelerating && useAccel) — these
+    /// were collapsed into one field previously, so non-accelerating shots
+    /// where IsAccel=1/UseAccel=0 (or vice-versa) were predicted wrong.
+    bool     useAccel       = false;
+    float    acceleration   = 0.f;
+    /// Cached 1/Acceleration when game stores inverse (ProjectileProperties.AccelerationInv).
+    float    accelerationInv = 0.f;
+    /// Alternate linear accel term (ProjectileProperties.VelocityChangeRate).
+    float    velocityChangeRate = 0.f;
+    /// 1 / VelocityChangeRate when the game stores inverse (ProjectileProperties.VelocityChangeRateInv).
+    float    velocityChangeRateInv = 0.f;
+    float    accelDelay     = 0.f;
+    float    speedClamp     = 0.f;
+    /// Spawn-time ProjectileProperties* for late refresh of *Value fields.
+    void*    projPropsPtr   = nullptr;
+    uint64_t spawnTick      = 0;
+    bool     valid          = false;
+    bool     canHitPlayer   = false;
+    bool     hasCachedPath  = false;
+    int      pathSampleCount = 0;
+    float    pathSampleTimesMs[kWorldProjectilePathSampleCap]{};
+    float    pathX[kWorldProjectilePathSampleCap]{};
+    float    pathY[kWorldProjectilePathSampleCap]{};
+    int32_t  attackerObjId  = 0;
+    uint32_t ownerObjId     = 0;
+    bool     hasCustomHitbox = false;
+    float    customOffsetX   = 0.f;
+    float    customOffsetY   = 0.f;
+    /// ProjectileProperties.LaserDistance (+0x170); >0 => laser-style capped ray (Flash parity).
+    bool     laser           = false;
+    float    laserDistance   = 0.f;
+    /// ProjectileProperties.IsTurning (+0x1B0) — shot traces a circular arc.
+    bool     isTurning          = false;
+    /// PP[0x1B1] — "circle-turn delayed" subtype: arc uses circleTurnAngle/turnStopTime as omega
+    /// and circleTurnDelay as the straight-travel phase. Distinct from isTurningDelayed.
+    bool     isCircleTurnDelayed = false;
+    /// ProjectileProperties.IsTurningDelayed (+0x1B2) — TurnRate-based delayed arc; straight phase = turnRateDelay ms.
+    bool     isTurningDelayed   = false;
+    /// PP[0x1B5] — when true the arc caps at turnStopTime and the shot continues straight.
+    /// When false (common) the arc keeps curving for the full projectile lifetime.
+    bool     turnSnapsToStraight = false;
+    /// PP[0x1B3] — boomerang / accelerated-turn flag; enables quadratic turn-angle modification.
+    bool     isTurningAccelerated = false;
+    /// ProjectileProperties.ProjectileTurnRate (+0xD4). XML TurnAngle is in radians PER 50 ms tick;
+    /// ProjPosAt converts to rad/ms via omega = turnRate / 50. (Old code used turnRate/turnStopTime,
+    /// which was 20× too slow for typical 1000 ms turn windows.)
+    float    turnRate           = 0.f;
+    /// ProjectileProperties.ProjectileTurnStopTime (+0xE8) ms.
+    float    turnStopTime       = 0.f;
+    /// ProjectileProperties.ProjectileTurnRateDelay (+0xD8) ms (normalized from seconds); delay for isTurningDelayed.
+    float    turnRateDelay      = 0.f;
+    /// ProjectileProperties.ProjectileCircleTurnAngle (+0xEC) — total arc angle for isCircleTurnDelayed path.
+    float    circleTurnAngle    = 0.f;
+    /// ProjectileProperties.ProjectileCircleTurnDelay (+0xF0) ms — straight-line phase before isCircleTurnDelayed arc.
+    float    circleTurnDelay    = 0.f;
+    /// PP[0xDC] — turn acceleration rate for boomerang shots.
+    float    turnAcceleration    = 0.f;
+    /// PP[0xE0] — time threshold (seconds) before boomerang accel kicks in.
+    float    turnAccelDelay      = 0.f;
+    /// PP[0xE4] — target / clamped turn rate for boomerang accel.
+    float    turnClamp           = 0.f;
+    /// PP[0x1AC] — inverse-accel threshold scale for boomerang two-segment blend.
+    float    turnAccelInv        = 0.f;
+};
+
+// WorldAoe source — which hook path recorded this entry.
+static constexpr uint8_t kAoeSrcGjj  = 0;  // GJJCEFJMNMK::KOBMINBDOBD  (throwable entity init)
+static constexpr uint8_t kAoeSrcFhoh = 1;  // FHOHCELBPDO::KOBMINBDOBD  (visual fallback)
+static constexpr uint8_t kAoeSrcExpl = 2;  // FGOFPGIIEPC::KOBMINBDOBD  (explosion controller)
+static constexpr uint8_t kAoeSrcSfx  = 3;  // HJMBOMEHGDJ::CGBILOJJPEI  (ShowEffect packet)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WorldAoe — ground-target AOE zone captured from four hook paths:
+//   GJJ  (kAoeSrcGjj):  GJJCEFJMNMK throwable entity. ownerObjId = throwable's objectId.
+//   FHOH (kAoeSrcFhoh): FHOHCELBPDO visual fallback.  ownerObjId = visual object's objectId.
+//   EXPL (kAoeSrcExpl): FGOFPGIIEPC explosion ring.   ownerObjId = anchor (thrower) entity objectId.
+//   SFX  (kAoeSrcSfx):  ShowEffect packet handler.    ownerObjId = packet targetObjectId (source entity).
+//
+// ownerObjId meaning by source:
+//   GJJ/FHOH → objectId of the throwable/visual entity (NOT the thrower — isEnemy deferred via pos-match)
+//   EXPL/SFX → objectId of the actual thrower / source entity (direct isEnemy lookup)
+// ─────────────────────────────────────────────────────────────────────────────
+struct WorldAoe
+{
+    float    x           = 0.f;    // throw origin world X  (GJJCEFJMNMK+0x368 / SFX pos1.x)
+    float    y           = 0.f;    // throw origin world Y  (GJJCEFJMNMK+0x36C / SFX pos1.y)
+    float    destX       = 0.f;    // landing spot X        (GJJCEFJMNMK+0x370 / SFX pos2.x for THROW)
+    float    destY       = 0.f;    // landing spot Y        (GJJCEFJMNMK+0x374 / SFX pos2.y for THROW)
+    float    radius      = 0.f;    // GJJ/FHOH/SFX: kDefaultAoeRadiusTiles (2.0); EXPL: CustomExplosionEntrance+0x38
+    float    innerR      = 0.f;    // inner radius if annular, 0 = filled disk
+    float    lifetime    = 3000.f; // total duration ms
+    float    arcMs       = 0.f;    // arc flight duration (distance/speed × 1000) when known from
+                                   // CustomExplosionEntrance; 0 = use heuristic. Planner uses this
+                                   // as the arming window so severity ramps during arc, peaks at blast.
+    uint64_t spawnTick   = 0;      // GetTickCount64() at capture time
+    bool     valid       = false;
+    bool     isDamaging      = false;  // true = throwable / explosion AOE
+    bool     isEnemy         = false;  // true = thrown by enemy; false = player/friendly
+    bool     isEnemyChecked  = false;  // true = isEnemy resolved from ObjectProperties
+    uint8_t  source          = kAoeSrcGjj;  // which hook path captured this entry
+    int32_t  sfxEffectType   = 0;          // SFX only: ShowEffect effectType (4=THROW 5=NOVA 23=CIRC 39=AOE)
+    void*    ptr             = nullptr; // GJJ/FHOH: live entity*; EXPL/SFX: nullptr
+    int32_t  ownerObjId      = 0;      // see source-specific meaning above
+};
+
+namespace WorldTAB {
+    void Render();
+    void ForceRefresh();    // trigger a DoRefresh() from external callers (e.g. TestTAB)
+
+    // Last-known local player data (updated on each successful DoRefresh).
+    // May be stale/null if WorldTAB has not been refreshed since injecting.
+    void*     GetLocalPtr();    // FKALGHJIADI* from WorldManager.OCLNLBHDEFK
+    float     GetLocalX();
+    float     GetLocalY();
+    // Live read +0x3C/+0x40 from local player object (same as movement / W2S anchor); falls back to last refresh.
+    void      ReadLocalWorldXYLive(float& outX, float& outY);
+    uintptr_t GetAppMgrPtr();   // ApplicationManager* (for WritePointerDataDict chain)
+
+    // Live-read the world position of an entity by objectId from the cached entity list.
+    // Returns true and fills outX/outY if the entity is found and its ptr is still readable.
+    bool GetEntityLivePos(int32_t objectId, float& outX, float& outY);
+
+    // Find the objectId of the player whose IGN best matches query (partial, case-insensitive).
+    // Priority: exact > starts-with > contains. Fills outMatchedName with the actual IGN.
+    bool FindPlayerByName(const char* query, int32_t& outObjectId, char* outMatchedName, int nameLen);
+
+    // Read-only snapshots of the last-refreshed entity and tile lists.
+    const std::vector<WorldEntity>& GetEntities();
+    const std::vector<WorldTile>&   GetTiles();
+    const std::vector<WorldProjectile>& GetProjectiles();
+
+    // Returns true if tile (tx, ty) blocks movement.
+    // Flash isWalkable() parity: NoWalk ground OR entity with OccupySquare OR FullOccupy.
+    // Damaging tiles are NOT in this set; they are physically walkable.
+    bool IsTileBlocked(int tx, int ty);
+
+    // Returns true if tile (tx, ty) has a FullOccupy entity.
+    // Used for the Flash isValidPosition sub-tile neighbour check (section B):
+    // neighbouring FullOccupy tiles constrain which fractional sub-position within
+    // a walkable tile the player can occupy.  Distinct from IsTileBlocked.
+    bool IsTileFullOccupied(int tx, int ty);
+
+    // Returns true if the tile at (tx, ty) deals damage.
+    // Damage triggers when the player centre (floor of world XY) is on the tile —
+    // NOT when the hitbox overlaps it.  Use floor(worldX/Y) for the lookup.
+    bool IsDamagingTile(int tx, int ty);
+
+    // Returns the XML speed multiplier of the tile at (tx, ty).
+    // 0.0 = no modifier, > 1.0 = speedy ground, < 1.0 = slow ground.
+    float GetTileSpeed(int tx, int ty);
+
+    // Reads the current world/map name via ABKHBJOKLJH (WorldManager property, RVA 0x4045E0).
+    // Writes a null-terminated ASCII string into buf. Returns false if unavailable.
+    bool ReadMapName(char* buf, int bufLen);
+}


### PR DESCRIPTION
Splits the massive ProjectileTracking file into scoped modules:
  - ProjectileRuntimeReader: reads live projectile properties from IL2CPP
  - ProjectileStore: ring-buffer + critical-section storage for active projectiles
  - ProjectileTrajectory: calls game positionAt() via runtime-resolved method pointer (resolves HBEAKBIHANL::GIBLKPDHLBG via IL2CPP metadata — global stub was null)

WorldTAB and ProjectileTracking updated to use the new modules.