### PR TITLE
Refactored Autoaim System

### DIFF
--- a/internal/il2cpp-dll-injection.vcxproj
+++ b/internal/il2cpp-dll-injection.vcxproj
@@ -86,6 +86,11 @@
     <ClCompile Include="src\features\account\CharSelect.cpp" />
     <ClCompile Include="src\features\account\CredentialCapture.cpp" />
     <ClCompile Include="src\features\combat\autoaim\AutoAim.cpp" />
+    <ClCompile Include="src\features\combat\autoaim\AimMath.cpp" />
+    <ClCompile Include="src\features\combat\autoaim\WeaponProfile.cpp" />
+    <ClCompile Include="src\features\combat\autoaim\TargetSelector.cpp" />
+    <ClCompile Include="src\features\combat\autoaim\AimHooks.cpp" />
+    <ClCompile Include="src\features\combat\enemytracker\EnemyTracker.cpp" />
     <ClCompile Include="src\features\combat\autoability\AutoAbility.cpp" />
     <ClCompile Include="src\features\movement\dodge\AoeTracking.cpp" />
     <ClCompile Include="src\features\visuals\skins\character\SkinChanger.cpp" />
@@ -198,6 +203,11 @@
     <ClInclude Include="src\features\account\CharSelect.h" />
     <ClInclude Include="src\features\account\CredentialCapture.h" />
     <ClInclude Include="src\features\combat\autoaim\AutoAim.h" />
+    <ClInclude Include="src\features\combat\autoaim\AimMath.h" />
+    <ClInclude Include="src\features\combat\autoaim\WeaponProfile.h" />
+    <ClInclude Include="src\features\combat\autoaim\TargetSelector.h" />
+    <ClInclude Include="src\features\combat\autoaim\AimHooks.h" />
+    <ClInclude Include="src\features\combat\enemytracker\EnemyTracker.h" />
     <ClInclude Include="src\features\combat\autoability\AutoAbility.h" />
     <ClInclude Include="src\features\movement\dodge\AoeTracking.h" />
     <ClInclude Include="src\features\visuals\skins\character\SkinChanger.h" />

--- a/internal/src/features/combat/autoaim/AimHooks.cpp
+++ b/internal/src/features/combat/autoaim/AimHooks.cpp
@@ -1,0 +1,214 @@
+#include "pch-il2cpp.h"
+
+#include "AimHooks.h"
+#include "WeaponProfile.h"
+#include "GameState.h"
+#include "RuntimeOffsets.h"
+#include "Il2CppResolver.h"
+#include "minhook/MinHook.h"
+
+#include <Windows.h>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+// ── IL2CPP method names ───────────────────────────────────────────────────────
+static const char* kPlayerClass   = "LKHPPBEGNOM";
+static const char* kShootClass    = "FKALGHJIADI";
+static const char* kCSAMethod     = "ELCBJAFBLJG"; // ComputeShootAngle
+static const char* kSWAMethod     = "EHGHCACPAGH"; // ShootWithAngle
+static const char* kSSPMethod     = "PMIANFBMMNN"; // SendShotPacket
+
+static const uint32_t& kOffPosX       = RuntimeOffsets::PosX;
+static const uint32_t& kOffPosY       = RuntimeOffsets::PosY;
+// shotData+0x1C is the angle field in the SHOOT packet struct
+static constexpr uint32_t kOffShotAngle = 0x1C;
+
+// ── Weapon-specific proj IDs ──────────────────────────────────────────────────
+static constexpr int32_t kProjIdCultStaff    = 0xB0EB; // Staff of Unholy Sacrifice
+static constexpr int32_t kProjIdColossusSlash = 0xB106; // Sword of the Colossus
+
+// ── Shared aim state (written each tick by AutoAim coordinator) ───────────────
+static std::atomic<bool>  s_hasTarget{ false };
+static std::atomic<float> s_targetX{ 0.f };
+static std::atomic<float> s_targetY{ 0.f };
+static std::atomic<bool>  s_reverseCultStaff{ true };
+static std::atomic<bool>  s_offsetColossus{ false };
+static std::atomic<bool>  s_enabled{ false };
+
+// ── Hook function-pointer types ───────────────────────────────────────────────
+using ComputeShootAngleFn = void(__fastcall*)(void*, uint8_t, float*, bool*, bool, void*);
+using ShootWithAngleFn    = void(__fastcall*)(void*, float, void*);
+using SendShotPacketFn    = void(__fastcall*)(void*, void*, int32_t, void*);
+
+static ComputeShootAngleFn g_csaOrig = nullptr;
+static ShootWithAngleFn    g_swaOrig = nullptr;
+static SendShotPacketFn    g_sspOrig = nullptr;
+static void* g_csaTarget = nullptr;
+static void* g_swaTarget = nullptr;
+static void* g_sspTarget = nullptr;
+static bool  s_installed = false;
+
+static inline bool AddrOk(const void* p) {
+    const uintptr_t a = reinterpret_cast<uintptr_t>(p);
+    return a > 0x10000 && a < 0x7FFFFFFFFFFFULL;
+}
+
+static float ApplyWeaponTweaks(float angle)
+{
+    const int32_t pid = WeaponCalibrator::GetProfile().projId;
+    if (s_reverseCultStaff.load(std::memory_order_relaxed) && pid == kProjIdCultStaff)
+        angle += 3.14159265f;
+    if (s_offsetColossus.load(std::memory_order_relaxed) && pid == kProjIdColossusSlash)
+        angle += 0.f; // TODO: extract exact offset from Multitool DLL
+    return angle;
+}
+
+static bool ShouldRedirect(void* player)
+{
+    if (!s_enabled.load(std::memory_order_relaxed)) return false;
+    if (!s_hasTarget.load(std::memory_order_relaxed)) return false;
+    if (!AddrOk(player)) return false;
+    void* local = GameState::GetLocalPtr();
+    return local && player == local;
+}
+
+// ── Detour implementations ────────────────────────────────────────────────────
+void __fastcall ComputeShootAngleDetour(
+    void* player, uint8_t slot, float* outAngle, bool* outCanShoot, bool boolArg, void* method)
+{
+    g_csaOrig(player, slot, outAngle, outCanShoot, boolArg, method);
+    if (!ShouldRedirect(player) || !outAngle) return;
+
+    float px = 0.f, py = 0.f;
+    __try {
+        uint8_t* lp = reinterpret_cast<uint8_t*>(player);
+        px = *reinterpret_cast<float*>(lp + kOffPosX);
+        py = *reinterpret_cast<float*>(lp + kOffPosY);
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return; }
+
+    *outAngle = ApplyWeaponTweaks(atan2f(
+        s_targetY.load(std::memory_order_relaxed) - py,
+        s_targetX.load(std::memory_order_relaxed) - px));
+}
+
+void __fastcall ShootWithAngleDetour(void* player, float angle, void* method)
+{
+    if (ShouldRedirect(player)) {
+        float px = 0.f, py = 0.f;
+        bool ok = false;
+        __try {
+            uint8_t* lp = reinterpret_cast<uint8_t*>(player);
+            px = *reinterpret_cast<float*>(lp + kOffPosX);
+            py = *reinterpret_cast<float*>(lp + kOffPosY);
+            ok = true;
+        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+        if (ok) {
+            angle = ApplyWeaponTweaks(atan2f(
+                s_targetY.load(std::memory_order_relaxed) - py,
+                s_targetX.load(std::memory_order_relaxed) - px));
+        }
+    }
+    g_swaOrig(player, angle, method);
+}
+
+void __fastcall SendShotPacketDetour(void* player, void* shotData, int32_t projCount, void* method)
+{
+    if (ShouldRedirect(player) && AddrOk(shotData) &&
+        AddrOk(reinterpret_cast<const uint8_t*>(shotData) + 0x24) && projCount > 0)
+    {
+        float px = 0.f, py = 0.f;
+        bool ok = false;
+        __try {
+            uint8_t* lp = reinterpret_cast<uint8_t*>(player);
+            px = *reinterpret_cast<float*>(lp + kOffPosX);
+            py = *reinterpret_cast<float*>(lp + kOffPosY);
+            ok = true;
+        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+        if (ok) {
+            const float newAngle = ApplyWeaponTweaks(atan2f(
+                s_targetY.load(std::memory_order_relaxed) - py,
+                s_targetX.load(std::memory_order_relaxed) - px));
+            __try {
+                *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(shotData) + kOffShotAngle) = newAngle;
+            } __except (EXCEPTION_EXECUTE_HANDLER) {}
+            __try {
+                *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(player) +
+                    RuntimeOffsets::Player_FacingAngle) = newAngle;
+            } __except (EXCEPTION_EXECUTE_HANDLER) {}
+        }
+    }
+    g_sspOrig(player, shotData, projCount, method);
+}
+
+static void* ResolveMethod(const char* cls, const char* method, int params)
+{
+    Il2CppClass* klass = Resolver::GetClass("", cls);
+    if (!klass) return nullptr;
+    const MethodInfo* mi = il2cpp_class_get_method_from_name(klass, method, params);
+    return (mi && mi->methodPointer) ? reinterpret_cast<void*>(mi->methodPointer) : nullptr;
+}
+
+} // namespace
+
+namespace AimHooks {
+
+bool Install()
+{
+    if (s_installed) return true;
+
+    g_csaTarget = ResolveMethod(kPlayerClass, kCSAMethod, 4);
+    g_swaTarget = ResolveMethod(kShootClass,  kSWAMethod, 1);
+    g_sspTarget = ResolveMethod(kShootClass,  kSSPMethod, 2);
+    if (!g_csaTarget || !g_swaTarget || !g_sspTarget) return false;
+
+    static bool s_mhInit = false;
+    if (!s_mhInit) {
+        MH_STATUS st = MH_Initialize();
+        if (st != MH_OK && st != MH_ERROR_ALREADY_INITIALIZED) return false;
+        s_mhInit = true;
+    }
+
+    if (MH_CreateHook(g_csaTarget, reinterpret_cast<void*>(&ComputeShootAngleDetour),
+                      reinterpret_cast<void**>(&g_csaOrig)) != MH_OK) return false;
+    if (MH_CreateHook(g_swaTarget, reinterpret_cast<void*>(&ShootWithAngleDetour),
+                      reinterpret_cast<void**>(&g_swaOrig)) != MH_OK) return false;
+    if (MH_CreateHook(g_sspTarget, reinterpret_cast<void*>(&SendShotPacketDetour),
+                      reinterpret_cast<void**>(&g_sspOrig)) != MH_OK) return false;
+
+    MH_EnableHook(g_csaTarget);
+    MH_EnableHook(g_swaTarget);
+    MH_EnableHook(g_sspTarget);
+
+    s_installed = true;
+    return true;
+}
+
+void Uninstall()
+{
+    if (!s_installed) return;
+    s_enabled.store(false, std::memory_order_release);
+    if (g_csaTarget) { MH_DisableHook(g_csaTarget); MH_RemoveHook(g_csaTarget); }
+    if (g_swaTarget) { MH_DisableHook(g_swaTarget); MH_RemoveHook(g_swaTarget); }
+    if (g_sspTarget) { MH_DisableHook(g_sspTarget); MH_RemoveHook(g_sspTarget); }
+    g_csaOrig = nullptr; g_swaOrig = nullptr; g_sspOrig = nullptr;
+    g_csaTarget = g_swaTarget = g_sspTarget = nullptr;
+    s_installed = false;
+}
+
+bool IsInstalled() { return s_installed; }
+
+void SetTarget(bool hasTarget, float x, float y)
+{
+    s_hasTarget.store(hasTarget, std::memory_order_relaxed);
+    s_targetX.store(x, std::memory_order_relaxed);
+    s_targetY.store(y, std::memory_order_relaxed);
+    s_enabled.store(true, std::memory_order_relaxed);
+}
+
+void SetReverseCultStaff(bool v)   { s_reverseCultStaff.store(v, std::memory_order_relaxed); }
+void SetOffsetColossusSword(bool v) { s_offsetColossus.store(v, std::memory_order_relaxed); }
+
+} // namespace AimHooks

--- a/internal/src/features/combat/autoaim/AimHooks.h
+++ b/internal/src/features/combat/autoaim/AimHooks.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+// MinHook detours for the three game methods involved in shot angle redirection.
+// Install() resolves IL2CPP method pointers and creates hooks; safe to call
+// every tick until it succeeds (self-guards with installed flag).
+namespace AimHooks {
+
+bool Install();
+void Uninstall();
+bool IsInstalled();
+
+// Called by AutoAim coordinator each tick before hooks may fire.
+void SetTarget(bool hasTarget, float x, float y);
+
+// Weapon-specific angle tweaks
+void SetReverseCultStaff(bool v);
+void SetOffsetColossusSword(bool v);
+
+} // namespace AimHooks

--- a/internal/src/features/combat/autoaim/AimMath.cpp
+++ b/internal/src/features/combat/autoaim/AimMath.cpp
@@ -1,0 +1,119 @@
+#include "pch-il2cpp.h"
+
+#include "AimMath.h"
+#include "RuntimeOffsets.h"
+#include "ProjectileTracking.h"
+
+#include <cmath>
+#include <cstdint>
+
+namespace AimMath {
+
+float QuadraticIntercept(float px, float py,
+                         float ex, float ey,
+                         float vx, float vy,
+                         float speed,
+                         float& outAimX, float& outAimY,
+                         float maxLeadSeconds)
+{
+    const float dx = ex - px, dy = ey - py;
+    const float a  = vx * vx + vy * vy - speed * speed;
+    const float b  = 2.f * (dx * vx + dy * vy);
+    const float c  = dx * dx + dy * dy;
+
+    float t = -1.f;
+    if (fabsf(a) < 1e-5f) {
+        // Near-linear: enemy speed ≈ proj speed
+        if (fabsf(b) > 1e-9f) t = -c / b;
+    } else {
+        const float disc = b * b - 4.f * a * c;
+        if (disc >= 0.f) {
+            const float sqD = sqrtf(disc);
+            const float t1  = (-b + sqD) / (2.f * a);
+            const float t2  = (-b - sqD) / (2.f * a);
+            if (t2 > 0.f && (t1 <= 0.f || t2 < t1))
+                t = t2;
+            else if (t1 > 0.f)
+                t = t1;
+        }
+    }
+
+    if (t > 0.f && t <= maxLeadSeconds) {
+        outAimX = ex + vx * t;
+        outAimY = ey + vy * t;
+        return t;
+    }
+    outAimX = ex;
+    outAimY = ey;
+    return -1.f;
+}
+
+static float ResolveLinearAccel(uint8_t* pp)
+{
+    const float a = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Acceleration);
+    if (std::isfinite(a) && fabsf(a) > 1e-6f) return a;
+
+    const float ai = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_AccelerationInv);
+    if (std::isfinite(ai) && fabsf(ai) > 1e-12f) return 1.f / ai;
+
+    const float vr = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_VelocityChangeRate);
+    if (std::isfinite(vr) && fabsf(vr) > 1e-6f) return vr;
+
+    const float vi = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_VelocityChangeRateInv);
+    if (std::isfinite(vi) && fabsf(vi) > 1e-12f) return 1.f / vi;
+
+    return 0.f;
+}
+
+float IntegratedProjectileDistance(uint8_t* projProps, float lifetimeMs, float speedMul, float rawSpeed)
+{
+    const float clampedMul = (speedMul > 1e-6f && speedMul < 100.f) ? speedMul : 1.f;
+    const float baseTpMs   = (rawSpeed / 10000.f) * clampedMul;
+    if (!(lifetimeMs > 0.f)) return 0.f;
+
+    float accel = ResolveLinearAccel(projProps);
+    const bool isBoomerang = *reinterpret_cast<bool*>(projProps + RuntimeOffsets::PP_IsBoomerang);
+    if (fabsf(accel) <= 1e-6f && isBoomerang && lifetimeMs > 1e-3f && rawSpeed > 1.f && rawSpeed <= 50000.f)
+        accel = -2.f * rawSpeed / lifetimeMs;
+
+    if (fabsf(accel) <= 1e-6f)
+        return lifetimeMs * baseTpMs;
+
+    const float accelTpMs2 = (accel / 1000000.f) * clampedMul;
+    const float rawDelay   = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_AccelDelay);
+    const float delayMs    = ProjectileTracking::NormalizeAccelDelayMs(rawDelay);
+    const float scaledDelay = (delayMs > 0.f) ? delayMs / clampedMul : 0.f;
+
+    if (lifetimeMs <= scaledDelay)
+        return lifetimeMs * baseTpMs;
+
+    const float seg0       = scaledDelay * baseTpMs;
+    const float accelTime  = lifetimeMs - scaledDelay;
+    float accelDist = baseTpMs * accelTime + 0.5f * accelTpMs2 * accelTime * accelTime;
+
+    const float clampVal = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_SpeedClamp);
+    if (clampVal > 0.f && std::isfinite(clampVal)) {
+        const float clampTpMs = (clampVal / 1000.f) * clampedMul;
+        if (accelTpMs2 > 1e-12f && clampTpMs > baseTpMs) {
+            const float tToClamp = (clampTpMs - baseTpMs) / accelTpMs2;
+            if (tToClamp > 0.f && accelTime > tToClamp) {
+                const float pre = baseTpMs * tToClamp + 0.5f * accelTpMs2 * tToClamp * tToClamp;
+                accelDist = pre + clampTpMs * (accelTime - tToClamp);
+            }
+        } else if (accelTpMs2 < -1e-12f && clampTpMs < baseTpMs && clampTpMs >= 0.f) {
+            const float tToFloor = (baseTpMs - clampTpMs) / (-accelTpMs2);
+            if (tToFloor > 0.f && accelTime > tToFloor) {
+                const float toFloor = baseTpMs * tToFloor + 0.5f * accelTpMs2 * tToFloor * tToFloor;
+                accelDist = toFloor + clampTpMs * (accelTime - tToFloor);
+            }
+        }
+    } else if (accelTpMs2 < 0.f) {
+        const float tToStop = baseTpMs / (-accelTpMs2);
+        if (tToStop > 0.f && accelTime > tToStop)
+            accelDist = baseTpMs * tToStop + 0.5f * accelTpMs2 * tToStop * tToStop;
+    }
+
+    return seg0 + accelDist;
+}
+
+} // namespace AimMath

--- a/internal/src/features/combat/autoaim/AimMath.h
+++ b/internal/src/features/combat/autoaim/AimMath.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+// Pure, stateless math utilities for aim lead and projectile range calculations.
+namespace AimMath {
+
+// Closed-form quadratic intercept (multitool sub_180003e20 equivalent).
+// Solves for the smallest positive t such that |enemyPos + enemyVel*t - playerPos| == speed*t.
+// t, enemyVel, and speed are all in the same unit (seconds + tiles/sec, or ms + tiles/ms).
+// maxLeadSeconds clamps t so lead never predicts beyond what the projectile can physically reach.
+// Returns t > 0 and sets outAimX/Y on success; returns -1 and sets outAimX/Y = enemyPos on failure.
+float QuadraticIntercept(float px, float py,
+                         float ex, float ey,
+                         float vx, float vy,          // enemy velocity (tiles/sec)
+                         float speed,                  // projectile speed (tiles/sec)
+                         float& outAimX, float& outAimY,
+                         float maxLeadSeconds = 2.f);
+
+// Integrates projectile distance accounting for speed, acceleration, deceleration,
+// boomerang heuristic, and speed clamps.  Uses RuntimeOffsets::PP_* fields.
+// lifetimeMs must already have the player lifetime multiplier applied.
+// speedMul is the player projectile speed multiplier.
+float IntegratedProjectileDistance(uint8_t* projProps, float lifetimeMs, float speedMul, float rawSpeed);
+
+} // namespace AimMath

--- a/internal/src/features/combat/autoaim/AutoAim.cpp
+++ b/internal/src/features/combat/autoaim/AutoAim.cpp
@@ -1,1614 +1,239 @@
 #include "pch-il2cpp.h"
 
 #include "AutoAim.h"
+#include "AimHooks.h"
+#include "WeaponProfile.h"
+#include "TargetSelector.h"
+#include "features/combat/enemytracker/EnemyTracker.h"
 #include "GameState.h"
-#include "gui/tabs/TestTAB.h"
+#include "RuntimeOffsets.h"
 #include "ProjectileTracking.h"
 #include "AoeTracking.h"
-#include "helpers.h"
-#include "Il2CppResolver.h"
-#include "RuntimeOffsets.h"
-#include "DbgFileLog.h"
-#include <string>
-
-#include "minhook/MinHook.h"
 
 #include <Windows.h>
 #include <atomic>
 #include <cmath>
 #include <cstdint>
-#include <unordered_map>
-#include <fstream>
-#include <sstream>
-#include <cstdio>
 
 namespace {
 
-// Game-specific offsets â€” resolved at runtime by RuntimeOffsets::EnsureAll().
-static const uint32_t& kOffPosX     = RuntimeOffsets::PosX;
-static const uint32_t& kOffPosY     = RuntimeOffsets::PosY;
-static const uint32_t& kOffHp       = RuntimeOffsets::HP;
-static const uint32_t& kOffMaxHp    = RuntimeOffsets::MaxHP;
-static const uint32_t& kOffObjProps      = RuntimeOffsets::ObjProps;         // KJMONHENJEN.OBAKMCCDBJA â†’ ObjectProperties*
-static const uint32_t& kOffOpIsEnemy     = RuntimeOffsets::OP_IsEnemy;       // ObjectProperties.isEnemy (XML <Enemy/>)
-static const uint32_t& kOffOpNoHealthBar = RuntimeOffsets::OP_NoHealthBar;   // ObjectProperties.noHealthBar â€” no visible HP bar
-static const uint32_t& kOffOpInvincElem  = RuntimeOffsets::OP_InvincibleElem;// ObjectProperties.InvincibleElement â€” non-null = permanently invincible
-static const uint32_t& kOffObjType       = RuntimeOffsets::ObjType;          // KJMONHENJEN.HFDNHJFNEKA â€” entity objectType
-static const uint32_t& kOffMoConds       = RuntimeOffsets::MoConditions;     // LKHPPBEGNOM.COHCKAPOLCA UInt32[]
-
-constexpr uint32_t kIl2CppArrMaxLen = 0x18;
-constexpr uint32_t kIl2CppArrData  = 0x20;
-
-// Object types excluded from auto-aim, wizard cluster scans, and any other path using SehReadEnemyCandidate.
-static constexpr int32_t kIgnoredEnemyObjectTypes[] = { 28491 };
-
-// Quest / boss objectType IDs â€” these are prioritised as first-pass targets.
-// Sourced from multitool Class27.list_0 (hardcoded quest-priority list).
-// These are aimed at first even if non-quest enemies exist.
-static constexpr int32_t kQuestObjectTypes[] = {
-    1337, 2048, 2340, 2349, 3448, 3449, 3452, 3613, 3622, 4312,
-    4324, 4325, 4326, 5943, 8200, 24092, 24327, 24351, 24363, 24587,
-    29003, 29021, 29039, 29341, 29342, 29723, 29764, 30026, 45104, 45371,
-    45076, 28618, 28619, 32751, 29793
-};
-
-static bool IsQuestObjectType(int32_t objType)
-{
-    for (int32_t q : kQuestObjectTypes) {
-        if (q == objType) return true;
-    }
-    return false;
-}
-
-static bool IsIgnoredEnemyObjectType(int32_t objType)
-{
-    for (int32_t ignored : kIgnoredEnemyObjectTypes) {
-        if (ignored == objType)
-            return true;
-    }
-    return false;
-}
-
-// Object types explicitly allowed for auto-aim even if they trip generic filters.
-// Used to bypass the maxHp==200 heuristic and any ignored-type filter.
-static constexpr int32_t kAutoAimWhitelistedObjectTypes[] = { 31104 };
-
-static bool IsWhitelistedEnemyObjectType(int32_t objType)
-{
-    for (int32_t allowed : kAutoAimWhitelistedObjectTypes) {
-        if (allowed == objType)
-            return true;
-    }
-    return false;
-}
-
-// Object types that should only be aimed at when no other valid targets exist.
-// (Lowest priority auto-aim list.)
-static constexpr int32_t kAutoAimFallbackObjectTypes[] = { 2928 };
-
-static bool IsFallbackEnemyObjectType(int32_t objType)
-{
-    for (int32_t allowed : kAutoAimFallbackObjectTypes) {
-        if (allowed == objType)
-            return true;
-    }
-    return false;
-}
-
-// Default aim-range bias (tiles beyond computed weapon range). Exposed via g_rangeLeadBias /
-// AutoAim::SetRangeLeadBias â€” matches multitool AutoAimRangeLead.
-// Default aim-range bias — Multitool Settings.AutoAimRangeLead = 1.0.
-static constexpr float kDefaultRangeLeadBiasTiles = 1.0f;
-// Character-side projectile tuning fields used by the decompiled AutoAim helpers.
-// The RE notes have not named these yet, but the decompiled formulas treat +0x188
-// as the projectile speed multiplier and +0x18C as the projectile lifetime/range multiplier.
-// xrDriver FUN_18011ed00 (CalcMaxRange) also reads *(float*)(player + 0x6b8) as an
-// additional final range multiplier after the base speed*lifetime integration.
-static constexpr uint32_t kOffCharProjSpeedMul    = 0x188;
-static constexpr uint32_t kOffCharProjLifetimeMul = 0x18C;
-static constexpr uint32_t kOffCharProjRangeMul    = 0x6B8;
-static constexpr uint32_t kOffProjId              = 0x15C;
-// Projectile objectType ids (objects.xml) — Multitool weapon-specific aim tweaks.
-static constexpr int32_t kProjIdCultistFireShot = 0xB0EB; // Staff of Unholy Sacrifice
-static constexpr int32_t kProjIdColossusSlash    = 0xB106; // Sword of the Colossus
-
-static const uint32_t& kOffWmDict   = RuntimeOffsets::WM_AllDict;
-// IL2CPP Dictionary<int,T> / Array layout â€” .NET runtime invariants, not game-specific.
-constexpr uint32_t kOffDictEnt   = 0x18;
-constexpr uint32_t kOffDictCnt   = 0x20;
-constexpr uint32_t kOffArrMax    = 0x18;
-constexpr uint32_t kOffArrData   = 0x20;
-constexpr int      kEntryStride  = 24;
-// kOffShotAngle: angle field in the SHOOT packet struct at +0x1C (4th slot after 0x10 header).
-// TODO: resolve via il2cpp once the exact packet class name is confirmed in the dump.
-constexpr uint32_t kOffShotAngle = 0x1C;
-
-// â”€â”€ Dynamic method resolution config â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-// Update these names from a fresh runtime dump when the game updates.
-// The resolver finds methods via IL2CPP metadata at runtime, so RVAs
-// are never hardcoded and ASLR is irrelevant.
-static const char* kPlayerClassName = "LKHPPBEGNOM";  // player entity class
-static const char* kShootClassName  = "FKALGHJIADI";  // shoot-handler class
-static const char* kCSAMethodName   = "ELCBJAFBLJG";  // ComputeShootAngle
-static const int   kCSAParamCount   = 4;
-static const char* kSWAMethodName   = "EHGHCACPAGH";  // ShootWithAngle
-static const int   kSWAParamCount   = 1;
-static const char* kSSPMethodName   = "PMIANFBMMNN";  // SendShotPacket
-static const int   kSSPParamCount   = 2;
-
-static void* g_csaTarget = nullptr;
-static void* g_swaTarget = nullptr;
-static void* g_sspTarget = nullptr;
-
-struct AimVelEntry {
-    float     x = 0.f;
-    float     y = 0.f;
-    ULONGLONG t = 0;
-    float     vx = 0.f;
-    float     vy = 0.f;
-};
-
-using ComputeShootAngleFn = void(__fastcall*)(void* player, uint8_t slotIndex, float* outAngle, bool* outCanShoot, bool boolArg, void* method);
-using ShootWithAngleFn    = void(__fastcall*)(void* player, float angle, void* method);
-using SendShotPacketFn    = void(__fastcall*)(void* player, void* shotData, int32_t projCount, void* method);
-
-ComputeShootAngleFn g_ComputeShootAngleOriginal = nullptr;
-ShootWithAngleFn    g_ShootWithAngleOriginal    = nullptr;
-SendShotPacketFn    g_SendShotPacketOriginal    = nullptr;
-
-std::atomic<bool>        g_autoAimEnabled{ false };
-std::atomic<bool>        g_enemyNextTickOverlay{ false };
-std::atomic<int>         g_aimMode{ 0 };   // Multitool AutoAimMode: 0 closest, 1 highest HP, 2 mouse
-std::atomic<float>       g_aimTargetX{ 0.f };
-std::atomic<float>       g_aimTargetY{ 0.f };
-std::atomic<bool>        g_hasAimTarget{ false };
-
-// Feature toggles (Multitool AutoAim* config + xrDriver DAT_* globals).
-std::atomic<bool>        g_shootInvulnerable{ false };     // AutoAimShootInvulnerable
-std::atomic<bool>        g_prioritizeBosses{ false };   // PrioritizeBosses — quest/boss targets prioritised; normal enemies still valid
-std::atomic<bool>        g_ignoreWalls{ true };            // AutoAimIgnoreWalls
-std::atomic<bool>        g_reverseCultStaff{ true };       // AutoAimReverseCultStaff
-std::atomic<bool>        g_offsetColossusSword{ false };   // AutoAimOffsetColossusSword
-std::atomic<bool>        g_shootWhileStealthed{ true };    // AutoAimShootWhileStealthed (Settings migration default)
-std::atomic<bool>        g_mouseBoundingEnabled{ true };   // xrDriver MouseBounding; always on in mouse mode
-std::atomic<float>       g_mouseBoundingRange{ 2.f };      // AutoAimMouseDist (Multitool default 2.0 tiles)
-std::atomic<float>       g_rangeLeadBias{ kDefaultRangeLeadBiasTiles }; // AutoAimRangeLead
-std::atomic<int32_t>     g_aimFocusEnemyId{ 0 };
-std::atomic<void*>       g_lastLocalProjProps{ nullptr };
-std::atomic<int32_t>     g_lastLocalProjId{ 0 };
-std::atomic<float>       g_playerProjSpeedMul{ 1.f };
-std::atomic<float>       g_playerProjLifetimeMul{ 1.f };
-std::atomic<float>       g_playerProjSpeedRaw{ 10000.f };
-std::atomic<float>       g_playerProjLifetimeMs{ 2000.f };  // read from projProps+0x158 at spawn
-std::atomic<float>       g_playerProjRangeTiles{ 15.f };    // decomp-style max range cache
-std::atomic<float>       g_playerProjAverageSpeedTps{ 10.f };
-// True once the range has been resolved from REAL data — either a
-// successful RefreshEquippedWeaponRange chain or a fired shot's
-// projProps. Lets the planner distinguish detected range from the
-// placeholder default, so it can fall back to the user's manual setting.
-std::atomic<bool>        g_playerProjRangeResolved{ false };
-// Realm-transition suspension deadline (GetTickCount64). Aim Tick body
-// no-ops while now < deadline; keeps shoot hooks from firing at stale
-// pointers from the previous world.
-std::atomic<uint64_t>    g_suspendUntilMs{ 0 };
-// Diagnostic counters for the passive equipped-weapon range refresh.
-std::atomic<uint32_t>    g_wrRefreshAttempts { 0 };
-std::atomic<uint32_t>    g_wrRefreshSuccesses{ 0 };
-std::atomic<const char*> g_wrLastError    { "init" };
-
-std::atomic<bool>        g_allowTick{ false };
-
-std::unordered_map<int32_t, AimVelEntry> g_aimVelMap;
-ULONGLONG                g_aimVelPruneAt = 0;
-
-ULONGLONG                g_firstInstallTick = 0;
-bool                     g_hooksInstalled = false;
-
-static void*             s_tickLastPlayerPtr = nullptr;
-static ULONGLONG         s_lastTickThrottleMs = 0;
-
-static inline bool AddrOk(const void* p)
-{
+static inline bool AddrOk(const void* p) {
     const uintptr_t a = reinterpret_cast<uintptr_t>(p);
     return a > 0x10000 && a < 0x7FFFFFFFFFFFULL;
 }
 
-// â”€â”€ AutoAim diagnostic logger â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-// Log path: C:\Users\trump\Desktop\Current\autoaim_debug.log
-static constexpr const char* kAimLogPath = "C:\\Users\\trump\\Desktop\\Current\\autoaim_debug.log";
-static ULONGLONG s_aimLogLastFlush = 0;
-static std::ostringstream s_aimLogBuf;
-static int s_aimLogEntries = 0;
-static constexpr int kAimLogMaxEntries = 120;  // cap to avoid huge files
+// ── Frame-level state ─────────────────────────────────────────────────────────
+static std::atomic<bool>    s_enabled{ false };
+static std::atomic<int>     s_aimModeInt{ 0 };
+static std::atomic<int32_t> s_lockedEnemyId{ -1 };
 
-static void AimLog(const char* msg)
+static std::atomic<bool>    s_shootInvulnerable{ false };
+static std::atomic<bool>    s_prioritizeBosses{ false };
+static std::atomic<bool>    s_ignoreWalls{ true };
+static std::atomic<bool>    s_shootWhileStealthed{ true };
+static std::atomic<bool>    s_mouseBoundingEnabled{ true };
+static std::atomic<float>   s_mouseBoundingRange{ 2.f };
+static std::atomic<float>   s_rangeLeadBias{ 1.f };
+static std::atomic<bool>    s_reverseCultStaff{ true };
+static std::atomic<bool>    s_offsetColossus{ false };
+
+static std::atomic<bool>    s_hasTarget{ false };
+static std::atomic<float>   s_aimX{ 0.f };
+static std::atomic<float>   s_aimY{ 0.f };
+static std::atomic<int32_t> s_aimFocusId{ 0 };
+
+static const int32_t*       s_skipObjTypes = nullptr;
+static int                  s_skipObjCount = 0;
+
+static ULONGLONG s_lastThrottleMs = 0;
+
+static bool LocalStealthBlocksAim(void* player)
 {
-    if (s_aimLogEntries >= kAimLogMaxEntries) return;
-    ++s_aimLogEntries;
-    s_aimLogBuf << msg << "\n";
-}
-
-static void AimLogFlush()
-{
-    const ULONGLONG now = GetTickCount64();
-    if (now - s_aimLogLastFlush < 2000ULL) return;
-    s_aimLogLastFlush = now;
-    if (s_aimLogBuf.str().empty()) return;
-    std::ofstream f(kAimLogPath, std::ios::app);
-    if (f.is_open()) {
-        f << s_aimLogBuf.str();
-        s_aimLogBuf.str("");
-        s_aimLogBuf.clear();
-    }
-}
-
-// Scan memory around a base address and dump values â€” used to find the real COHCKAPOLCA offset.
-// Writes one line per 4-byte slot over [base+startOff .. base+startOff+count*4].
-static void AimLogScanU32(const char* label, uint8_t* base, uint32_t startOff, int count)
-{
-    char line[256];
-    for (int i = 0; i < count; ++i) {
-        uint32_t off = startOff + static_cast<uint32_t>(i) * 4;
-        uint32_t val = 0;
-        __try { val = *reinterpret_cast<uint32_t*>(base + off); }
-        __except (EXCEPTION_EXECUTE_HANDLER) { val = 0xDEADBEEF; }
-        snprintf(line, sizeof(line), "  %s[+0x%X] = 0x%08X", label, off, val);
-        AimLog(line);
-    }
-}
-
-// Dump the candidate UInt32[] array at a given pointer field offset on entity.
-// Prints maxLen, data[0], data[1] so we can verify COHCKAPOLCA shape.
-static void AimLogCondArray(const char* label, uint8_t* entity, uint32_t fieldOff)
-{
-    char line[256];
-    void* arr = nullptr;
-    __try { arr = *reinterpret_cast<void**>(entity + fieldOff); }
-    __except (EXCEPTION_EXECUTE_HANDLER) { arr = nullptr; }
-
-    if (!arr || !AddrOk(arr)) {
-        snprintf(line, sizeof(line), "  %s @+0x%X: arr=NULL/bad", label, fieldOff);
-        AimLog(line);
-        return;
-    }
-    int32_t maxLen = 0;
-    uint32_t d0 = 0, d1 = 0;
-    __try {
-        uint8_t* a = reinterpret_cast<uint8_t*>(arr);
-        maxLen = *reinterpret_cast<int32_t*>(a + 0x18);
-        d0     = *reinterpret_cast<uint32_t*>(a + 0x20);
-        d1     = *reinterpret_cast<uint32_t*>(a + 0x24);
-    } __except (EXCEPTION_EXECUTE_HANDLER) { maxLen = -1; }
-
-    snprintf(line, sizeof(line), "  %s @+0x%X: arr=%p maxLen=%d d0=0x%08X d1=0x%08X",
-             label, fieldOff, arr, maxLen, d0, d1);
-    AimLog(line);
-}
-
-static bool GatesOpen()
-{
-    return g_autoAimEnabled.load(std::memory_order_relaxed);
-}
-
-// Multitool AutoAimShootWhileStealthed: when false, do not aim while local has Invisible.
-static bool LocalStealthBlocksAutoAim(void* player)
-{
-    if (g_shootWhileStealthed.load(std::memory_order_relaxed))
-        return false;
-    if (!AddrOk(player))
-        return false;
+    if (s_shootWhileStealthed.load(std::memory_order_relaxed)) return false;
+    if (!AddrOk(player)) return false;
     uint32_t w0 = 0, w1 = 0;
-    if (!RuntimeOffsets::TryReadMapObjectConditions(player, &w0, &w1))
-        return false;
+    if (!RuntimeOffsets::TryReadMapObjectConditions(player, &w0, &w1)) return false;
     const uint64_t full = RuntimeOffsets::GetFullConditions(w0, w1);
     return RuntimeOffsets::HasCondition(full, RuntimeOffsets::ConditionEffects::Invisible);
 }
 
-static bool AimRedirectionActive(void* player)
+static void RunTick()
 {
-    return GatesOpen() && !LocalStealthBlocksAutoAim(player);
-}
-
-// Staff of Unholy Sacrifice / Cultist Fire Shot — Multitool reverses firing direction (+π).
-// Sword of the Colossus / Colossus Slash — optional offset when enabled (exact radians TBD from Multitool DLL).
-static float MultitoolApplyWeaponAngleTweaks(float angleRad)
-{
-    const int32_t pid = g_lastLocalProjId.load(std::memory_order_relaxed);
-    float a = angleRad;
-    if (g_reverseCultStaff.load(std::memory_order_relaxed) && pid == kProjIdCultistFireShot)
-        a += 3.14159265f;
-    if (g_offsetColossusSword.load(std::memory_order_relaxed) && pid == kProjIdColossusSlash)
-        a += 0.f; // TODO: match Multitool version.dll fixed offset when extracted
-    return a;
-}
-
-static float ResolveProjectileLinearAccel(uint8_t* projProps)
-{
-    const float rawAccel = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_Acceleration);
-    if (std::isfinite(rawAccel) && fabsf(rawAccel) > 1e-6f)
-        return rawAccel;
-    const float accelInv = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_AccelerationInv);
-    if (std::isfinite(accelInv) && fabsf(accelInv) > 1e-12f)
-        return 1.f / accelInv;
-    const float velRate = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_VelocityChangeRate);
-    if (std::isfinite(velRate) && fabsf(velRate) > 1e-6f)
-        return velRate;
-    const float velRateInv = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_VelocityChangeRateInv);
-    if (std::isfinite(velRateInv) && fabsf(velRateInv) > 1e-12f)
-        return 1.f / velRateInv;
-    return 0.f;
-}
-static float IntegratedProjectileDistance(
-    uint8_t* projProps,
-    float lifetimeMs,
-    float speedMul,
-    float rawSpeed)
-{
-    const float clampedSpeedMul = (speedMul > 1e-6f && speedMul < 100.f) ? speedMul : 1.f;
-    const float baseSpeedTilesPerMs = (rawSpeed / 10000.f) * clampedSpeedMul;
-    if (!(lifetimeMs > 0.f))
-        return 0.f;
-    float accelLinear = ResolveProjectileLinearAccel(projProps);
-    const bool isBoomerang = *reinterpret_cast<bool*>(projProps + RuntimeOffsets::PP_IsBoomerang);
-    if (fabsf(accelLinear) <= 1e-6f && isBoomerang && lifetimeMs > 1e-3f && rawSpeed > 1.f && rawSpeed <= 50000.f)
-        accelLinear = -2.f * rawSpeed / lifetimeMs;
-    if (fabsf(accelLinear) <= 1e-6f)
-        return lifetimeMs * baseSpeedTilesPerMs;
-    const float accelTilesPerMs2 = (accelLinear / 1000000.f) * clampedSpeedMul;
-    const float rawDelay = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_AccelDelay);
-    const float delayMs = ProjectileTracking::NormalizeAccelDelayMs(rawDelay);
-    const float scaledDelayMs = (delayMs > 0.f) ? delayMs / clampedSpeedMul : 0.f;
-    if (lifetimeMs <= scaledDelayMs)
-        return lifetimeMs * baseSpeedTilesPerMs;
-    const float firstSegment = scaledDelayMs * baseSpeedTilesPerMs;
-    const float accelTimeMs = lifetimeMs - scaledDelayMs;
-    float accelDistance = baseSpeedTilesPerMs * accelTimeMs + 0.5f * accelTilesPerMs2 * accelTimeMs * accelTimeMs;
-    const float speedClamp = *reinterpret_cast<float*>(projProps + RuntimeOffsets::PP_SpeedClamp);
-    if (speedClamp > 0.f && std::isfinite(speedClamp)) {
-        const float clampTilesPerMs = (speedClamp / 1000.f) * clampedSpeedMul;
-        if (accelTilesPerMs2 > 1e-12f && clampTilesPerMs > baseSpeedTilesPerMs) {
-            const float timeToClamp = (clampTilesPerMs - baseSpeedTilesPerMs) / accelTilesPerMs2;
-            if (timeToClamp > 0.f && accelTimeMs > timeToClamp) {
-                const float preClamp = baseSpeedTilesPerMs * timeToClamp +
-                    0.5f * accelTilesPerMs2 * timeToClamp * timeToClamp;
-                accelDistance = preClamp + clampTilesPerMs * (accelTimeMs - timeToClamp);
-            }
-        } else if (accelTilesPerMs2 < -1e-12f && clampTilesPerMs < baseSpeedTilesPerMs && clampTilesPerMs >= 0.f) {
-            const float timeToFloor = (baseSpeedTilesPerMs - clampTilesPerMs) / (-accelTilesPerMs2);
-            if (timeToFloor > 0.f && accelTimeMs > timeToFloor) {
-                const float toFloor = baseSpeedTilesPerMs * timeToFloor +
-                    0.5f * accelTilesPerMs2 * timeToFloor * timeToFloor;
-                accelDistance = toFloor + clampTilesPerMs * (accelTimeMs - timeToFloor);
-            }
-        }
-    } else if (accelTilesPerMs2 < 0.f) {
-        const float timeToStop = baseSpeedTilesPerMs / (-accelTilesPerMs2);
-        if (timeToStop > 0.f && accelTimeMs > timeToStop) {
-            accelDistance = baseSpeedTilesPerMs * timeToStop +
-                0.5f * accelTilesPerMs2 * timeToStop * timeToStop;
-        }
-    }
-    return firstSegment + accelDistance;
-}
-static bool ReadLocalProjectileTuners(void* local, float& outSpeedMul, float& outLifetimeMul, float& outRangeMul)
-{
-    if (!AddrOk(local))
-        return false;
-    __try {
-        uint8_t* p = reinterpret_cast<uint8_t*>(local);
-        outSpeedMul = *reinterpret_cast<float*>(p + kOffCharProjSpeedMul);
-        outLifetimeMul = *reinterpret_cast<float*>(p + kOffCharProjLifetimeMul);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-    outRangeMul = 1.f;
-    __try {
-        outRangeMul = *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(local) + kOffCharProjRangeMul);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        outRangeMul = 1.f;
-    }
-    if (!std::isfinite(outSpeedMul) || outSpeedMul <= 0.f || outSpeedMul > 100.f)
-        outSpeedMul = 1.f;
-    if (!std::isfinite(outLifetimeMul) || outLifetimeMul <= 0.f || outLifetimeMul > 100.f)
-        outLifetimeMul = 1.f;
-    if (!std::isfinite(outRangeMul) || outRangeMul <= 0.f || outRangeMul > 100.f)
-        outRangeMul = 1.f;
-    return true;
-}
-static void UpdateAutoAimValues(void* local)
-{
-    void* projProps = g_lastLocalProjProps.load(std::memory_order_relaxed);
-    if (!AddrOk(local) || !AddrOk(projProps))
-        return;
-    float speedMul = 1.f;
-    float lifetimeMul = 1.f;
-    float rangeMul = 1.f;
-    if (!ReadLocalProjectileTuners(local, speedMul, lifetimeMul, rangeMul))
-        return;
-    __try {
-        uint8_t* pp = reinterpret_cast<uint8_t*>(projProps);
-        const int32_t rawSpeedInt = *reinterpret_cast<int32_t*>(pp + RuntimeOffsets::PP_Speed);
-        if (rawSpeedInt <= 100 || rawSpeedInt >= 500000)
-            return;
-        const float rawSpeed = static_cast<float>(rawSpeedInt);
-        const float rawLifetime = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Lifetime);
-        const float lifetimeMs = ProjectileTracking::NormalizeProjectileLifetimeMs(rawLifetime) * lifetimeMul;
-        if (!(lifetimeMs > 1.f) || !std::isfinite(lifetimeMs))
-            return;
-        float maxRangeTiles = 0.f;
-        if (*reinterpret_cast<bool*>(pp + RuntimeOffsets::PP_IsParametric)) {
-            const float magnitude = *reinterpret_cast<float*>(pp + RuntimeOffsets::PP_Magnitude);
-            maxRangeTiles = (std::isfinite(magnitude) && magnitude > 0.f) ? magnitude * speedMul : 0.f;
-        } else {
-            maxRangeTiles = IntegratedProjectileDistance(pp, lifetimeMs, speedMul, rawSpeed);
-        }
-        if (!(maxRangeTiles > 0.f) || !std::isfinite(maxRangeTiles))
-            return;
-        // xrDriver FUN_18011ed00 applies player+0x6b8 as a final range scalar on top of speed*lifetime.
-        maxRangeTiles *= rangeMul;
-        float averageSpeedTps = (maxRangeTiles / lifetimeMs) * 1000.f;
-        if (!(averageSpeedTps > 0.01f) || !std::isfinite(averageSpeedTps))
-            averageSpeedTps = (rawSpeed / 10000.f) * speedMul * 1000.f;
-        g_playerProjSpeedMul.store(speedMul, std::memory_order_relaxed);
-        g_playerProjLifetimeMul.store(lifetimeMul, std::memory_order_relaxed);
-        g_playerProjSpeedRaw.store(rawSpeed, std::memory_order_relaxed);
-        g_playerProjLifetimeMs.store(lifetimeMs, std::memory_order_relaxed);
-        g_playerProjRangeTiles.store(maxRangeTiles, std::memory_order_relaxed);
-        g_playerProjAverageSpeedTps.store(averageSpeedTps, std::memory_order_relaxed);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
-}
-
-// FacingAngle hook: LKHPPBEGNOM_ACCKOGJECPB @ 0x01B51FE0
-// DIA4A's primary/recommended hook. Returns the facing angle baseline â€” overriding
-// here makes the player sprite rotate to face target and feeds the correct angle
-// into ComputeShootAngle as its starting point.
-// ComputeShootAngle hook: LKHPPBEGNOM_ELCBJAFBLJG @ 0x01B54BA0
-// Called by the game to resolve final shot angle + canShoot flag.
-// Strategy: call original first (so canShoot logic runs normally), then
-// overwrite *outAngle with atan2(target - player). One write here propagates
-// to projectile visual, packet field, and server hit-reg â€” the primary hook
-// for actual shot redirection (FacingAngle was cosmetic-only and crashes on
-// Detours trampolines during realm entity initialization).
-
-void __fastcall ComputeShootAngleDetour(
-    void*    player,
-    uint8_t  slotIndex,
-    float*   outAngle,
-    bool*    outCanShoot,
-    bool     boolArg,
-    void*    method)
-{
-    g_ComputeShootAngleOriginal(player, slotIndex, outAngle, outCanShoot, boolArg, method);
-
-    if (!AimRedirectionActive(player)) return;
-    if (!AddrOk(player)) return;
+    const bool aimOn = s_enabled.load(std::memory_order_relaxed);
 
     void* local = GameState::GetLocalPtr();
-    if (!local || player != local) return;
-    if (!g_hasAimTarget.load(std::memory_order_relaxed)) return;
-    if (!outAngle) return;
+
+    // Aim is inactive — clear target. Hooks must be installed and the player must
+    // not be stealthed (when ShootWhileStealthed is off).
+    if (!aimOn || !local || !AimHooks::IsInstalled() || LocalStealthBlocksAim(local)) {
+        s_hasTarget.store(false, std::memory_order_relaxed);
+        s_aimFocusId.store(0, std::memory_order_relaxed);
+        AimHooks::SetTarget(false, 0.f, 0.f);
+        return;
+    }
+
+    // Refresh shared data sources for target selection. EnemyTracker::Tick is
+    // self-throttled, so callers of EnumerateLiveEnemies can also trigger it.
+    WeaponCalibrator::Tick(local);
+    EnemyTracker::Tick();
 
     float px = 0.f, py = 0.f;
     __try {
-        uint8_t* lp = reinterpret_cast<uint8_t*>(player);
-        px = *reinterpret_cast<float*>(lp + kOffPosX);
-        py = *reinterpret_cast<float*>(lp + kOffPosY);
-    } __except (EXCEPTION_EXECUTE_HANDLER) { return; }
-
-    float tx = g_aimTargetX.load(std::memory_order_relaxed);
-    float ty = g_aimTargetY.load(std::memory_order_relaxed);
-    *outAngle = MultitoolApplyWeaponAngleTweaks(atan2f(ty - py, tx - px));
-}
-
-void __fastcall ShootWithAngleDetour(void* player, float angle, void* method)
-{
-    if (AimRedirectionActive(player) && AddrOk(player)) {
-        void* local = GameState::GetLocalPtr();
-        if (local && player == local && g_hasAimTarget.load(std::memory_order_relaxed)) {
-            float px2 = 0.f, py2 = 0.f;
-            __try {
-                uint8_t* lp = reinterpret_cast<uint8_t*>(player);
-                px2 = *reinterpret_cast<float*>(lp + kOffPosX);
-                py2 = *reinterpret_cast<float*>(lp + kOffPosY);
-            } __except (EXCEPTION_EXECUTE_HANDLER) {
-                g_ShootWithAngleOriginal(player, angle, method);
-                return;
-            }
-            float tx = g_aimTargetX.load(std::memory_order_relaxed);
-            float ty = g_aimTargetY.load(std::memory_order_relaxed);
-            float newAngle = MultitoolApplyWeaponAngleTweaks(atan2f(ty - py2, tx - px2));
-            g_ShootWithAngleOriginal(player, newAngle, method);
-            return;
-        }
-    }
-    g_ShootWithAngleOriginal(player, angle, method);
-}
-
-void __fastcall SendShotPacketDetour(void* player, void* shotData, int32_t projCount, void* method)
-{
-    // Realm / handshake paths may call with projCount==0 or non-standard shotData; skip writes (DIA4A parity for combat only).
-    const bool shotBufOk =
-        AddrOk(shotData) && AddrOk(reinterpret_cast<const uint8_t*>(shotData) + 0x24); // cover shotData+0x1C float write
-    if (AimRedirectionActive(player) && AddrOk(player) && shotBufOk && projCount > 0) {
-        void* local = GameState::GetLocalPtr();
-        if (local && player == local && g_hasAimTarget.load(std::memory_order_relaxed)) {
-            float px2 = 0.f, py2 = 0.f;
-            __try {
-                uint8_t* lp = reinterpret_cast<uint8_t*>(player);
-                px2 = *reinterpret_cast<float*>(lp + kOffPosX);
-                py2 = *reinterpret_cast<float*>(lp + kOffPosY);
-            } __except (EXCEPTION_EXECUTE_HANDLER) {
-                g_SendShotPacketOriginal(player, shotData, projCount, method);
-                return;
-            }
-            float tx = g_aimTargetX.load(std::memory_order_relaxed);
-            float ty = g_aimTargetY.load(std::memory_order_relaxed);
-            float newAngle = MultitoolApplyWeaponAngleTweaks(atan2f(ty - py2, tx - px2));
-            __try {
-                *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(shotData) + kOffShotAngle) = newAngle;
-            } __except (EXCEPTION_EXECUTE_HANDLER) {}
-            __try {
-                *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(player) + RuntimeOffsets::Player_FacingAngle) = newAngle;
-            } __except (EXCEPTION_EXECUTE_HANDLER) {}
-        }
-    }
-    g_SendShotPacketOriginal(player, shotData, projCount, method);
-}
-
-// C2712: __try cannot share a function with std::unordered_map (AutoAimThreadProc). Isolate SEH here.
-static bool SehReadLocalKlassAndPos(void* local, float* outX, float* outY, uint64_t* outKlass)
-{
-    __try {
         uint8_t* lp = reinterpret_cast<uint8_t*>(local);
-        *outX = *reinterpret_cast<float*>(lp + kOffPosX);
-        *outY = *reinterpret_cast<float*>(lp + kOffPosY);
-        *outKlass = *reinterpret_cast<uint64_t*>(lp);
-        return true;
+        px = *reinterpret_cast<float*>(lp + RuntimeOffsets::PosX);
+        py = *reinterpret_cast<float*>(lp + RuntimeOffsets::PosY);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-// wm: WorldMgr ptr (from GameState::GetWorldMgr()); appMgr param unused, kept for signature compat.
-static bool SehResolveAllDict(void* wm, void** /*unused*/, void** outAllDict)
-{
-    __try {
-        if (!AddrOk(wm))
-            return false;
-        void* ad = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(wm) + kOffWmDict);
-        *outAllDict = ad;
-        return AddrOk(ad);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-static bool SehReadDictArrayHeader(void* allDict, void** outEntries, int32_t* outCount)
-{
-    __try {
-        *outEntries = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(allDict) + kOffDictEnt);
-        *outCount = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(allDict) + kOffDictCnt);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-static bool SehReadArrayMaxLength(void* entriesArr, int32_t* outMaxLen)
-{
-    __try {
-        *outMaxLen = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(entriesArr) + kOffArrMax);
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-// Closed-form quadratic intercept (same as multitool sub_180003e20).
-// Solves for the smallest positive t such that |enemyPos + enemyVel*t - playerPos| == speed*t.
-// t is in seconds; enemyVel and speed are tiles/sec.
-// Returns t >= 0 and sets outAimX/Y on success; returns -1 and sets outAimX/Y = enemyPos on failure.
-static float QuadraticIntercept(float px, float py, float ex, float ey,
-                                 float vx, float vy, float speed,
-                                 float& outAimX, float& outAimY)
-{
-    const float dx = ex - px, dy = ey - py;
-    const float a  = vx * vx + vy * vy - speed * speed;
-    const float b  = 2.f * (dx * vx + dy * vy);
-    const float c  = dx * dx + dy * dy;
-
-    float t = -1.f;
-    if (fabsf(a) < 1e-5f) {
-        // Near-linear: enemy speed â‰ˆ proj speed â€” simple t = -c/b
-        if (fabsf(b) > 1e-9f) t = -c / b;
-    } else {
-        const float disc = b * b - 4.f * a * c;
-        if (disc >= 0.f) {
-            const float sqD = sqrtf(disc);
-            const float t1  = (-b + sqD) / (2.f * a);
-            const float t2  = (-b - sqD) / (2.f * a);
-            // Pick smallest positive root (same logic as multitool)
-            if (t2 > 0.f && (t1 <= 0.f || t2 < t1))
-                t = t2;
-            else if (t1 > 0.f)
-                t = t1;
-        }
-    }
-
-    if (t > 0.f) {
-        outAimX = ex + vx * t;
-        outAimY = ey + vy * t;
-        return t;
-    }
-    outAimX = ex;
-    outAimY = ey;
-    return -1.f;
-}
-
-// Shared enemy filter: not local/same klass, ObjectProperties.isEnemy, valid HP,
-// no health bar, not permanently invincible, not runtime-untargetable.
-// outIsQuest is set to true when the entity's objectType is in the quest priority list.
-// outEntity (optional) receives the raw entity pointer for ECGPFJKCCAN velocity reading.
-// outIsInvulnerable (optional) is set to true when the entity has a non-empty InvincibleElement
-// string — only returned instead of rejected when g_shootInvulnerable is enabled.
-// outHp (optional) receives the entity's current HP for HighestHP aim mode.
-static bool SehReadEnemyCandidate(
-    uint8_t* entry,
-    void*    local,
-    uint64_t localKlass,
-    int32_t* outId,
-    float*   outX,
-    float*   outY,
-    int32_t* outObjType,
-    bool*    outIsQuest        = nullptr,
-    void**   outEntity         = nullptr,
-    bool*    outIsInvulnerable = nullptr,
-    int32_t* outHp             = nullptr)
-{
-    __try {
-        if (*reinterpret_cast<int32_t*>(entry) < 0)
-            return false;
-        void* entity = *reinterpret_cast<void**>(entry + 16);
-        if (!entity || entity == local)
-            return false;
-        uint64_t entKlass = *reinterpret_cast<uint64_t*>(entity);
-        if (entKlass == localKlass)
-            return false;
-        void* objProps = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(entity) + kOffObjProps);
-        if (!objProps || !AddrOk(objProps))
-            return false;
-        uint8_t* op = reinterpret_cast<uint8_t*>(objProps);
-        uint8_t* ent = reinterpret_cast<uint8_t*>(entity);
-
-        // â”€â”€ Diagnostic logging (first kAimLogMaxEntries isEnemy entities only) â”€â”€â”€â”€â”€â”€
-        static bool s_diagHeaderWritten = false;
-        const bool doLog = (s_aimLogEntries < kAimLogMaxEntries);
-        if (doLog) {
-            if (!s_diagHeaderWritten) {
-                s_diagHeaderWritten = true;
-                AimLog("=== AutoAim SehReadEnemyCandidate diag (first 120 isEnemy hits) ===");
-                char hdr[128];
-                snprintf(hdr, sizeof(hdr), "Offsets: HP=0x%X MaxHP=0x%X ObjType=0x%X ObjProps=0x%X",
-                         kOffHp, kOffMaxHp, kOffObjType, kOffObjProps);
-                AimLog(hdr);
-                snprintf(hdr, sizeof(hdr), "OP_IsEnemy=0x%X OP_NoHealthBar=0x%X OP_InvincElem=0x%X MoConds=0x%X",
-                         kOffOpIsEnemy, kOffOpNoHealthBar, kOffOpInvincElem, kOffMoConds);
-                AimLog(hdr);
-            }
-        }
-
-        // XML isEnemy flag.
-        if (!*reinterpret_cast<uint8_t*>(op + kOffOpIsEnemy))
-            return false;
-
-        // -- entity passed isEnemy, log it --
-        int32_t objTypeEarly = 0;
-        __try { objTypeEarly = *reinterpret_cast<int32_t*>(ent + kOffObjType); } __except(EXCEPTION_EXECUTE_HANDLER) {}
-        int32_t hpEarly = 0, maxHpEarly = 0;
-        __try { hpEarly   = *reinterpret_cast<int32_t*>(ent + kOffHp);    } __except(EXCEPTION_EXECUTE_HANDLER) {}
-        __try { maxHpEarly = *reinterpret_cast<int32_t*>(ent + kOffMaxHp); } __except(EXCEPTION_EXECUTE_HANDLER) {}
-
-        uint8_t noHB   = 0;
-        void*   invPtr = nullptr;
-        __try { noHB   = *reinterpret_cast<uint8_t*>(op + kOffOpNoHealthBar); } __except(EXCEPTION_EXECUTE_HANDLER) { noHB = 0xFF; }
-        __try { invPtr = *reinterpret_cast<void**>(op + kOffOpInvincElem);     } __except(EXCEPTION_EXECUTE_HANDLER) { invPtr = (void*)0xDEAD; }
-
-        // check InvincibleElement string length early so we can include it in the log line
-        int32_t invStrLen = -1;
-        if (invPtr && AddrOk(invPtr) && invPtr != (void*)0xDEAD) {
-            __try { invStrLen = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(invPtr) + 0x10); }
-            __except (EXCEPTION_EXECUTE_HANDLER) { invStrLen = -2; }
-        }
-
-        if (doLog) {
-            char line[256];
-            snprintf(line, sizeof(line),
-                "ent=%p type=%d hp=%d maxHp=%d noHB=%u invPtr=%p invLen=%d",
-                entity, objTypeEarly, hpEarly, maxHpEarly, noHB, invPtr, invStrLen);
-            AimLog(line);
-        }
-
-        // noHealthBar — Multitool AutoAimIgnoreWalls: when true, treat as wall/destructible (skip).
-        if (g_ignoreWalls.load(std::memory_order_relaxed) && noHB && noHB != 0xFF) {
-            if (doLog) AimLog("  -> REJECTED: noHealthBar");
-            return false;
-        }
-
-        // XML <Invincible/> static flag â€” InvincibleElement string pointer non-null = permanently invincible.
-        // Also check the string length to guard against empty-string false positives.
-        // When g_shootInvulnerable is true we keep invuln targets as candidates (but flag them so the
-        // caller can deprioritise them below non-invulnerable enemies). Matches multitool
-        // AutoAimShootInvulnerable / xrDriver targetInvulnerable behaviour.
-        bool isInvulnerable = false;
-        if (invPtr && AddrOk(invPtr) && invPtr != (void*)0xDEAD) {
-            int32_t strLen = -1;
-            __try { strLen = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(invPtr) + 0x10); }
-            __except (EXCEPTION_EXECUTE_HANDLER) { strLen = -1; }
-            if (strLen > 0) {
-                isInvulnerable = true;
-                if (!g_shootInvulnerable.load(std::memory_order_relaxed)) {
-                    if (doLog) { char l[128]; snprintf(l,sizeof(l),"  -> REJECTED: InvincibleElement strLen=%d", strLen); AimLog(l); }
-                    return false;
-                }
-            }
-        }
-
-        int32_t hp = *reinterpret_cast<int32_t*>(ent + kOffHp);
-        int32_t maxHp = *reinterpret_cast<int32_t*>(ent + kOffMaxHp);
-        if (hp <= 0 || maxHp <= 0) {
-            if (doLog) { char l[64]; snprintf(l,sizeof(l),"  -> REJECTED: hp=%d maxHp=%d", hp, maxHp); AimLog(l); }
-            return false;
-        }
-        const int32_t objType = *reinterpret_cast<int32_t*>(ent + kOffObjType);
-        const bool whitelisted = IsWhitelistedEnemyObjectType(objType);
-
-        if (!whitelisted) {
-            if (maxHp == 200 || (hp == 200 && maxHp == 0)) {
-                if (doLog) AimLog("  -> REJECTED: maxHp==200 heuristic");
-                return false;
-            }
-            if (IsIgnoredEnemyObjectType(objType)) {
-                if (doLog) AimLog("  -> REJECTED: ignored objType");
-                return false;
-            }
-        }
-
-        // Runtime condition check: use TryReadMapObjectConditions which has correct SEH
-        // handling and the same maxLen==2 guard.
-        // Root cause of the bug: the old manual array walk left cond0=cond1=0 whenever
-        // maxLen != 2 (which is always true for enemy entities, since COHCKAPOLCA is a
-        // player-class field and enemies store a float 1.0f there instead of an array
-        // pointer). MapObjectConditionsMakeUntargetable(0,0) always returned false, so
-        // invulnerable enemies were never rejected by the runtime condition check.
-        // Fix: delegate to TryReadMapObjectConditions and only apply the untargetable
-        // check when it successfully reads a valid UInt32[2] array (condReadOk==true
-        // and at least one word is non-zero). If the read fails or returns zero words
-        // (wrong entity class), we skip the runtime check and rely solely on the XML
-        // InvincibleElement check above, which already handles static invincibility.
-        uint32_t cond0 = 0, cond1 = 0;
-        const bool condReadOk = RuntimeOffsets::TryReadMapObjectConditions(entity, &cond0, &cond1);
-        if (condReadOk && (cond0 | cond1) != 0 && RuntimeOffsets::MapObjectConditionsMakeUntargetable(cond0, cond1)) {
-            if (doLog) { char l[128]; snprintf(l,sizeof(l),"  -> REJECTED: untargetable cond0=0x%08X cond1=0x%08X", cond0, cond1); AimLog(l); }
-            return false;
-        }
-        if (doLog) { char l[128]; snprintf(l,sizeof(l),"  -> PASSED all filters (condReadOk=%d cond0=0x%08X)", (int)condReadOk, cond0); AimLog(l); }
-
-        *outX = *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(entity) + kOffPosX);
-        *outY = *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(entity) + kOffPosY);
-        *outId = *reinterpret_cast<int32_t*>(entry + 8);
-        if (outObjType) *outObjType = objType;
-        if (outIsQuest) *outIsQuest = IsQuestObjectType(objType);
-        if (outEntity) *outEntity = entity;
-        if (outIsInvulnerable) *outIsInvulnerable = isInvulnerable;
-        if (outHp) *outHp = hp;
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        return false;
-    }
-}
-
-// Typical server NEWTICK step (~200 ms). Used to weight chord velocity when sample spacing matches one tick.
-static constexpr float kServerTickMsMin = 115.f;
-static constexpr float kServerTickMsMax = 290.f;
-// MoVelocity / finite-difference sanity: tiles/ms (10 tiles/s = 0.01; leave headroom).
-static constexpr float kMaxVelTilesPerMs = 0.1f;
-static constexpr float kMoVelSmooth = 0.65f; // blend toward fresh MoVelocity reads
-
-// Prefer ECGPFJKCCAN (MoVelocity) when resolved; else estimate chord velocity from successive
-// world positions. When dt between samples falls in kServerTickMs* range, weight raw dp/dt
-// heavily (server-style snapshot pair). QuadraticIntercept expects tiles/sec â€” multiply by 1000.
-static void UpdateAimVelForEntity(int32_t id, float ex, float ey, ULONGLONG nowAim, void* entity)
-{
-    float moVx = 0.f, moVy = 0.f;
-    bool haveMo = false;
-    const uint32_t velOff = RuntimeOffsets::MoVelocity;
-    if (velOff != 0 && AddrOk(entity)) {
-        __try {
-            uint8_t* ent = reinterpret_cast<uint8_t*>(entity);
-            float rvx = *reinterpret_cast<float*>(ent + velOff);
-            float rvy = *reinterpret_cast<float*>(ent + velOff + 4);
-            if (std::isfinite(rvx) && std::isfinite(rvy) &&
-                fabsf(rvx) < kMaxVelTilesPerMs && fabsf(rvy) < kMaxVelTilesPerMs) {
-                moVx = rvx;
-                moVy = rvy;
-                haveMo = true;
-            }
-        } __except (EXCEPTION_EXECUTE_HANDLER) {}
-    }
-
-    auto it = g_aimVelMap.find(id);
-    if (it == g_aimVelMap.end()) {
-        g_aimVelMap[id] = { ex, ey, nowAim, haveMo ? moVx : 0.f, haveMo ? moVy : 0.f };
+        s_hasTarget.store(false, std::memory_order_relaxed);
+        AimHooks::SetTarget(false, 0.f, 0.f);
         return;
     }
 
-    AimVelEntry& e = it->second;
+    TargetSelector::Config cfg;
+    cfg.mode                 = static_cast<TargetSelector::Mode>(s_aimModeInt.load(std::memory_order_relaxed));
+    cfg.shootInvulnerable    = s_shootInvulnerable.load(std::memory_order_relaxed);
+    cfg.prioritizeBosses     = s_prioritizeBosses.load(std::memory_order_relaxed);
+    cfg.ignoreWalls          = s_ignoreWalls.load(std::memory_order_relaxed);
+    cfg.rangeLeadBias        = s_rangeLeadBias.load(std::memory_order_relaxed);
+    cfg.mouseBoundingEnabled = s_mouseBoundingEnabled.load(std::memory_order_relaxed);
+    cfg.mouseBoundingRange   = s_mouseBoundingRange.load(std::memory_order_relaxed);
+    cfg.lockedEnemyId        = s_lockedEnemyId.load(std::memory_order_relaxed);
+    cfg.skipObjTypes         = s_skipObjTypes;
+    cfg.skipObjCount         = s_skipObjCount;
 
-    if (haveMo) {
-        e.vx = e.vx * (1.f - kMoVelSmooth) + moVx * kMoVelSmooth;
-        e.vy = e.vy * (1.f - kMoVelSmooth) + moVy * kMoVelSmooth;
-        e.x = ex;
-        e.y = ey;
-        e.t = nowAim;
-        return;
-    }
+    // Mouse world position is read inside TargetSelector::Select via TestTAB
+    const TargetSelector::Result result = TargetSelector::Select(
+        cfg, px, py, 0.f, 0.f, WeaponCalibrator::GetProfile());
 
-    const float dt = static_cast<float>(nowAim > e.t ? (nowAim - e.t) : 1ULL);
-    float dtClamped = dt;
-    if (dtClamped < 1.f) dtClamped = 1.f;
-    else if (dtClamped > 500.f) dtClamped = 500.f;
-    const float dx = ex - e.x;
-    const float dy = ey - e.y;
-    const float distSq = dx * dx + dy * dy;
-
-    // tiles/ms; linear client lerp has constant dp/dt along a segment, so per-poll iv matches chord rate.
-    float ivx = dx / dtClamped;
-    float ivy = dy / dtClamped;
-    const float instMag = sqrtf(ivx * ivx + ivy * ivy);
-    static constexpr float kMaxInstTilesPerMs = 0.08f;
-    if (instMag > kMaxInstTilesPerMs && instMag > 1e-8f) {
-        const float s = kMaxInstTilesPerMs / instMag;
-        ivx *= s;
-        ivy *= s;
-    }
-
-    float blend = 0.4f;
-    if (dt >= kServerTickMsMin && dt <= kServerTickMsMax && distSq > 1e-10f)
-        blend = 0.9f;
-
-    if (e.t != 0 && distSq > 1e-14f) {
-        e.vx = e.vx * (1.f - blend) + ivx * blend;
-        e.vy = e.vy * (1.f - blend) + ivy * blend;
-    } else if (distSq > 1e-14f) {
-        e.vx = ivx;
-        e.vy = ivy;
-    }
-
-    e.x = ex;
-    e.y = ey;
-    e.t = nowAim;
-}
-
-// Single aim tick: must run from Present/render thread (see AutoAim::Tick) â€” avoids racing realm transitions.
-// State-change-only logger for AutoAim. Kept OUT of RunAutoAimTickBody because
-// that function uses __try and MSVC forbids C++ object destructors (std::string,
-// std::ostringstream from DBG_FILE_LOG) in the same frame as SEH.
-static int s_autoAimLastBailReason = -1;
-
-__declspec(noinline) static void AutoAimLogBail(int reason, const char* msg)
-{
-    if (reason == s_autoAimLastBailReason) return;
-    s_autoAimLastBailReason = reason;
-    DBG_FILE_LOG("[AutoAim::Tick] state=" << msg);
-}
-
-__declspec(noinline) static void AutoAimLogRunning(int32_t count, int32_t maxLength, float px, float py)
-{
-    if (s_autoAimLastBailReason == 0) return;
-    s_autoAimLastBailReason = 0;
-    DBG_FILE_LOG("[AutoAim::Tick] state=running â€” count=" << count
-        << " maxLength=" << maxLength
-        << " player=(" << px << "," << py << ")");
-}
-
-static void RunAutoAimTickBody()
-{
-    const ULONGLONG now = GetTickCount64();
-    const bool pastInjectDelay = (g_firstInstallTick != 0) && (now - g_firstInstallTick > 3000ULL);
-
-    const bool aimEnabled = g_autoAimEnabled.load(std::memory_order_relaxed);
-    const bool wantVelOv  = g_enemyNextTickOverlay.load(std::memory_order_relaxed);
-
-    // GameState::Tick() (called before AutoAim::Tick in dPresent) handles all
-    // AppMgr/WorldMgr/LocalPtr resolution.  No ForceRefresh needed here.
-
-    if (!aimEnabled && !wantVelOv) {
-        g_hasAimTarget.store(false, std::memory_order_relaxed);
-        s_tickLastPlayerPtr = nullptr;
-        AutoAimLogBail(1, "disabled");
-        return;
-    }
-
-    void* local = GameState::GetLocalPtr();
-    if (!local) {
-        if (aimEnabled)
-            g_hasAimTarget.store(false, std::memory_order_relaxed);
-        s_tickLastPlayerPtr = nullptr;
-        AutoAimLogBail(2, "no LocalPtr from GameState");
-        return;
-    }
-
-    const bool stealthNoAim = LocalStealthBlocksAutoAim(local);
-    const bool wantAim      = aimEnabled && !stealthNoAim;
-
-    if (local != s_tickLastPlayerPtr)
-        s_tickLastPlayerPtr = local;
-
-    float playerX = 0.f, playerY = 0.f;
-    uint64_t localKlass = 0;
-    if (!SehReadLocalKlassAndPos(local, &playerX, &playerY, &localKlass)) {
-        if (wantAim)
-            g_hasAimTarget.store(false, std::memory_order_relaxed);
-        AutoAimLogBail(3, "SehReadLocalKlassAndPos failed (PosX/PosY offsets wrong?)");
-        return;
-    }
-    if (localKlass == 0) {
-        if (wantAim)
-            g_hasAimTarget.store(false, std::memory_order_relaxed);
-        AutoAimLogBail(4, "localKlass=0 (player not materialised yet)");
-        return;
-    }
-
-    UpdateAutoAimValues(local);
-
-    // WorldMgr is already resolved by GameState â€” just read AllDict from it.
-    void* allDict = nullptr;
-    if (!SehResolveAllDict(GameState::GetWorldMgr(), nullptr, &allDict)) {
-        if (wantAim)
-            g_hasAimTarget.store(false, std::memory_order_relaxed);
-        AutoAimLogBail(5, "SehResolveAllDict failed (WM_AllDict offset wrong?)");
-        return;
-    }
-
-    void* entriesArr = nullptr;
-    int32_t count = 0;
-    if (!SehReadDictArrayHeader(allDict, &entriesArr, &count) || !AddrOk(entriesArr) || count <= 0) {
-        if (wantAim)
-            g_hasAimTarget.store(false, std::memory_order_relaxed);
-        char tmp[64];
-        snprintf(tmp, sizeof(tmp), "SehReadDictArrayHeader count=%d", count);
-        AutoAimLogBail(6, tmp);
-        return;
-    }
-
-    int32_t maxLength = 0;
-    if (!SehReadArrayMaxLength(entriesArr, &maxLength)) {
-        if (wantAim)
-            g_hasAimTarget.store(false, std::memory_order_relaxed);
-        AutoAimLogBail(7, "SehReadArrayMaxLength failed");
-        return;
-    }
-
-    AutoAimLogRunning(count, maxLength, playerX, playerY);
-
-    int32_t limit = count;
-    if (limit > maxLength)
-        limit = maxLength;
-    if (limit > 4096)
-        limit = 4096;
-
-    uint8_t* vectorBase = reinterpret_cast<uint8_t*>(entriesArr) + kOffArrData;
-
-    const ULONGLONG nowAim = GetTickCount64();
-
-    const int aimModeInt = g_aimMode.load(std::memory_order_relaxed);
-    const bool useHighestHp  = (aimModeInt == static_cast<int>(AutoAim::AimMode::HighestHP));
-    const bool useMouseRef   = (aimModeInt == static_cast<int>(AutoAim::AimMode::ClosestToMouse));
-    const bool mouseBoundOn  = g_mouseBoundingEnabled.load(std::memory_order_relaxed);
-    const float mouseBoundR  = g_mouseBoundingRange.load(std::memory_order_relaxed);
-    const bool prioritizeBosses = g_prioritizeBosses.load(std::memory_order_relaxed);
-    const float leadBias     = g_rangeLeadBias.load(std::memory_order_relaxed);
-
-    // Reference point for "closest enemy" â€” player position normally, or mouse world pos in ClosestToMouse mode.
-    float refX = playerX, refY = playerY;
-    if (wantAim && useMouseRef) {
-        const float mx = TestTAB::GetMouseWorldX();
-        const float my = TestTAB::GetMouseWorldY();
-        if (mx != 0.f || my != 0.f) { refX = mx; refY = my; }
-    }
-
-    // Use actual weapon range (speed Ã— lifetime), clamped to a sane minimum â€” aim target only.
-    // Add g_rangeLeadBias so we track enemies slightly before they enter true shot range.
-    const float weaponRange = g_playerProjRangeTiles.load(std::memory_order_relaxed);
-    float kMaxRange = ((weaponRange > 2.f) ? weaponRange : 15.f) + leadBias;
-    // xrDriver MouseBoundingEnabled: clamp candidate-to-mouse distance to MouseBoundingRange.
-    if (wantAim && useMouseRef && mouseBoundOn && mouseBoundR > 0.f && mouseBoundR < kMaxRange)
-        kMaxRange = mouseBoundR;
-    const float kMaxRangeSq = kMaxRange * kMaxRange;
-
-    // Normal enemy tier (non-quest, non-fallback, non-invulnerable).
-    float   bestScoreDist = kMaxRangeSq;    // smaller is better
-    int32_t bestScoreHp   = -1;             // larger is better (HighestHP mode)
-    float   bestX = 0.f, bestY = 0.f;
-    int32_t bestId = 0;
-    void*   bestEntity = nullptr;
-    bool    found = false;
-
-    // Quest/boss priority tier â€” beats any normal tier pick regardless of distance/hp.
-    float   questScoreDist = kMaxRangeSq;
-    int32_t questScoreHp   = -1;
-    float   questBestX = 0.f, questBestY = 0.f;
-    int32_t questBestId = 0;
-    void*   questBestEntity = nullptr;
-    bool    questFound = false;
-
-    // Fallback tier (kAutoAimFallbackObjectTypes) â€” only used if nothing else matched.
-    float   fbScoreDist = kMaxRangeSq;
-    int32_t fbScoreHp   = -1;
-    float   fallbackBestX = 0.f, fallbackBestY = 0.f;
-    int32_t fallbackBestId = 0;
-    void*   fallbackBestEntity = nullptr;
-    bool    fallbackFound = false;
-
-    // Invulnerable tier â€” only populated when g_shootInvulnerable is on; below non-invuln tiers.
-    float   invScoreDist = kMaxRangeSq;
-    int32_t invScoreHp   = -1;
-    float   invBestX = 0.f, invBestY = 0.f;
-    int32_t invBestId = 0;
-    void*   invBestEntity = nullptr;
-    bool    invFound = false;
-
-    for (int32_t i = 0; i < limit; ++i) {
-        uint8_t* entry = vectorBase + i * kEntryStride;
-        int32_t eid = 0;
-        int32_t objType = 0;
-        float ex = 0.f, ey = 0.f;
-        bool isQuest = false;
-        bool isInvuln = false;
-        int32_t candHp = 0;
-        void* eptr = nullptr;
-        if (!SehReadEnemyCandidate(entry, local, localKlass, &eid, &ex, &ey, &objType,
-                                   &isQuest, &eptr, &isInvuln, &candHp))
-            continue;
-
-        UpdateAimVelForEntity(eid, ex, ey, nowAim, eptr);
-
-        if (!wantAim)
-            continue;
-
-        // Boss Prioritisation: when enabled, isQuest entities go to the quest tier
-        // (prioritised over normal enemies). When disabled, quest entities compete
-        // in the normal tier alongside other enemies. No entity is skipped — the
-        // toggle only controls which tier quest entities land in.
-
-        const float dx = ex - refX;
-        const float dy = ey - refY;
-        const float distSq = dx * dx + dy * dy;
-        if (distSq > kMaxRangeSq)
-            continue;
-
-        // HighestHP mode: compare by HP (larger wins); otherwise by distance (smaller wins).
-        auto beats = [&](float curDist, int32_t curHp, float newDist, int32_t newHp) {
-            if (useHighestHp)
-                return newHp > curHp || (newHp == curHp && newDist < curDist);
-            return newDist < curDist;
-        };
-
-        // Whitelisted entities always go to the normal tier (never prioritised).
-        const bool whitelisted = IsWhitelistedEnemyObjectType(objType);
-
-        if (prioritizeBosses && isQuest && !whitelisted) {
-            // Boss priority on: quest entities land in the quest tier (high priority).
-            if (beats(questScoreDist, questScoreHp, distSq, candHp)) {
-                questScoreDist = distSq;
-                questScoreHp   = candHp;
-                questBestX = ex; questBestY = ey;
-                questBestId = eid; questBestEntity = eptr;
-                questFound = true;
-            }
-        } else if (isInvuln) {
-            // Only reached when g_shootInvulnerable is on (filter rejects it otherwise).
-            if (beats(invScoreDist, invScoreHp, distSq, candHp)) {
-                invScoreDist = distSq;
-                invScoreHp   = candHp;
-                invBestX = ex; invBestY = ey;
-                invBestId = eid; invBestEntity = eptr;
-                invFound = true;
-            }
-        } else if (prioritizeBosses && isQuest) {
-            // Boss priority on but whitelisted: quest entity goes to normal tier.
-            if (beats(bestScoreDist, bestScoreHp, distSq, candHp)) {
-                bestScoreDist = distSq;
-                bestScoreHp   = candHp;
-                bestX = ex; bestY = ey;
-                bestId = eid; bestEntity = eptr;
-                found = true;
-            }
-        } else if (IsFallbackEnemyObjectType(objType)) {
-            if (beats(fbScoreDist, fbScoreHp, distSq, candHp)) {
-                fbScoreDist = distSq;
-                fbScoreHp   = candHp;
-                fallbackBestX = ex; fallbackBestY = ey;
-                fallbackBestId = eid; fallbackBestEntity = eptr;
-                fallbackFound = true;
-            }
-        } else {
-            // Boss priority off (or non-quest): quest entities compete in normal tier.
-            if (beats(bestScoreDist, bestScoreHp, distSq, candHp)) {
-                bestScoreDist = distSq;
-                bestScoreHp   = candHp;
-                bestX = ex; bestY = ey;
-                bestId = eid; bestEntity = eptr;
-                found = true;
-            }
-        }
-    }
-
-    // Priority: quest/boss > normal enemies > fallback > invulnerable.
-    if (wantAim && questFound) {
-        bestX = questBestX; bestY = questBestY; bestId = questBestId;
-        bestEntity = questBestEntity; found = true;
-    } else if (wantAim && !found && fallbackFound) {
-        bestX = fallbackBestX;
-        bestY = fallbackBestY;
-        bestId = fallbackBestId;
-        bestEntity = fallbackBestEntity;
-        found = true;
-    } else if (wantAim && !found && invFound) {
-        bestX = invBestX;
-        bestY = invBestY;
-        bestId = invBestId;
-        bestEntity = invBestEntity;
-        found = true;
-    }
-
-    if (nowAim >= g_aimVelPruneAt) {
-        g_aimVelPruneAt = nowAim + 5000ULL;
-        for (auto it2 = g_aimVelMap.begin(); it2 != g_aimVelMap.end();) {
-            if (nowAim - it2->second.t > 8000ULL)
-                it2 = g_aimVelMap.erase(it2);
-            else
-                ++it2;
-        }
-    }
-
-    float aimX = bestX, aimY = bestY;
-    if (wantAim && found && bestId != 0) {
-        // Velocity: already merged per-entity in UpdateAimVelForEntity (MoVelocity + chord fallback).
-        float vx = 0.f, vy = 0.f;
-        const auto itVel = g_aimVelMap.find(bestId);
-        if (itVel != g_aimVelMap.end()) {
-            vx = itVel->second.vx;
-            vy = itVel->second.vy;
-        }
-
-        // --- Compute effective projectile speed in tiles/sec (handles accelerating projs) ---
-        // Use total range / lifetime as average effective speed â€” multitool's approach:
-        //   projSpeed = sub_180003830(projProps, speedMult, lifetime) / (lifetime_s * speedMult)
-        // ProjectileTracking samples the game-authored projectile path directly.
-        float projSpeedTps = g_playerProjAverageSpeedTps.load(std::memory_order_relaxed);
-
-        if (projSpeedTps < 0.1f) projSpeedTps = 10.f; // guard
-
-        // QuadraticIntercept uses tiles/sec for enemy vel; map stores tiles/ms.
-        if (vx != 0.f || vy != 0.f) {
-            const float vxTps = vx * 1000.f;
-            const float vyTps = vy * 1000.f;
-            QuadraticIntercept(playerX, playerY, bestX, bestY, vxTps, vyTps, projSpeedTps, aimX, aimY);
-        }
-    }
-
-    if (wantAim) {
-        g_aimTargetX.store(aimX, std::memory_order_relaxed);
-        g_aimTargetY.store(aimY, std::memory_order_relaxed);
-        g_hasAimTarget.store(found, std::memory_order_relaxed);
-        g_aimFocusEnemyId.store(found ? bestId : 0, std::memory_order_relaxed);
-    } else {
-        g_hasAimTarget.store(false, std::memory_order_relaxed);
-        g_aimFocusEnemyId.store(0, std::memory_order_relaxed);
-    }
-
-    AimLogFlush();
-}
-
-// Standalone dict walk for combat helpers (cluster aim, etc.) â€” mirrors RunAutoAimTickBody entity loop.
-static void EnumerateLiveEnemiesBody(AutoAim::EnemyScanCallback cb, void* user)
-{
-    if (!cb)
-        return;
-
-    void* local = GameState::GetLocalPtr();
-    if (!local)
-        return;
-
-    float playerX = 0.f, playerY = 0.f;
-    uint64_t localKlass = 0;
-    if (!SehReadLocalKlassAndPos(local, &playerX, &playerY, &localKlass))
-        return;
-    if (localKlass == 0)
-        return;
-
-    void* allDict = nullptr;
-    if (!SehResolveAllDict(GameState::GetWorldMgr(), nullptr, &allDict))
-        return;
-
-    void* entriesArr = nullptr;
-    int32_t count = 0;
-    if (!SehReadDictArrayHeader(allDict, &entriesArr, &count) || !AddrOk(entriesArr) || count <= 0)
-        return;
-
-    int32_t maxLength = 0;
-    if (!SehReadArrayMaxLength(entriesArr, &maxLength))
-        return;
-
-    int32_t limit = count;
-    if (limit > maxLength)
-        limit = maxLength;
-    if (limit > 4096)
-        limit = 4096;
-
-    uint8_t* vectorBase = reinterpret_cast<uint8_t*>(entriesArr) + kOffArrData;
-
-    for (int32_t i = 0; i < limit; ++i) {
-        uint8_t* entry = vectorBase + i * kEntryStride;
-        int32_t eid = 0;
-        int32_t objType = 0;
-        float ex = 0.f, ey = 0.f;
-        if (!SehReadEnemyCandidate(entry, local, localKlass, &eid, &ex, &ey, &objType))
-            continue;
-        cb(ex, ey, eid, user);
-    }
+    s_hasTarget.store(result.found, std::memory_order_relaxed);
+    s_aimX.store(result.aimX, std::memory_order_relaxed);
+    s_aimY.store(result.aimY, std::memory_order_relaxed);
+    s_aimFocusId.store(result.found ? result.enemyId : 0, std::memory_order_relaxed);
+    AimHooks::SetTarget(result.found, result.aimX, result.aimY);
 }
 
 } // namespace
 
 namespace AutoAim {
 
-void Tick()
-{
-    // Retry every tick until actually installed. The old code called these
-    // once and set a one-shot flag EVEN ON FAILURE — if the projectile/AoE
-    // IL2CPP classes weren't registered yet at that single early Tick (game
-    // world still loading), the hooks never installed and projs stayed 0
-    // forever (XDodge had nothing to dodge). Both Install()s self-guard with
-    // `if (g_Installed) return;`, so this is a cheap no-op once done — same
-    // retry pattern as DangerPlanner::TryInstall and AutoAim's g_hooksInstalled.
-    ProjectileTracking::Install();
-    AoeTracking::Install();
-    if (!g_hooksInstalled) {
-        Install();
-        if (!g_hooksInstalled) return;
-    }
-
-    if (!g_allowTick.load(std::memory_order_acquire))
-        return;
-
-    const ULONGLONG wall = GetTickCount64();
-    if (wall - s_lastTickThrottleMs < 8ULL)
-        return;
-    s_lastTickThrottleMs = wall;
-
-    RunAutoAimTickBody();
-}
-
-void SetEnabled(bool on)
-{
-    g_autoAimEnabled.store(on, std::memory_order_relaxed);
-    if (!on)
-        g_hasAimTarget.store(false, std::memory_order_relaxed);
-    // GameState::Tick() runs every frame and keeps LocalPtr/WorldMgr current â€”
-    // no ForceRefresh needed.
-}
-
-bool IsEnabled()
-{
-    return g_autoAimEnabled.load(std::memory_order_relaxed);
-}
-
-void SetAimMode(AimMode mode)
-{
-    const int raw = static_cast<int>(mode);
-    // Clamp to known modes (0=ClosestToPlayer, 1=ClosestToMouse, 2=HighestHP).
-    const int clamped = (raw < 0 || raw > 2) ? 0 : raw;
-    g_aimMode.store(clamped, std::memory_order_relaxed);
-}
-
-AimMode GetAimMode()
-{
-    return static_cast<AimMode>(g_aimMode.load(std::memory_order_relaxed));
-}
-
-void SetShootInvulnerable(bool on)
-{
-    g_shootInvulnerable.store(on, std::memory_order_relaxed);
-}
-
-bool IsShootInvulnerable()
-{
-    return g_shootInvulnerable.load(std::memory_order_relaxed);
-}
-
-void SetPrioritizeBosses(bool on)
-{
-    g_prioritizeBosses.store(on, std::memory_order_relaxed);
-}
-
-bool IsPrioritizeBosses()
-{
-    return g_prioritizeBosses.load(std::memory_order_relaxed);
-}
-
-void SetMouseBoundingEnabled(bool on)
-{
-    g_mouseBoundingEnabled.store(on, std::memory_order_relaxed);
-}
-
-bool IsMouseBoundingEnabled()
-{
-    return g_mouseBoundingEnabled.load(std::memory_order_relaxed);
-}
-
-void SetMouseBoundingRange(float tiles)
-{
-    if (!std::isfinite(tiles) || tiles < 0.f) tiles = 0.f;
-    if (tiles > 200.f) tiles = 200.f;
-    g_mouseBoundingRange.store(tiles, std::memory_order_relaxed);
-}
-
-float GetMouseBoundingRange()
-{
-    return g_mouseBoundingRange.load(std::memory_order_relaxed);
-}
-
-void SetRangeLeadBias(float tiles)
-{
-    if (!std::isfinite(tiles) || tiles < 0.f) tiles = 0.f;
-    if (tiles > 50.f) tiles = 50.f;
-    g_rangeLeadBias.store(tiles, std::memory_order_relaxed);
-}
-
-float GetRangeLeadBias()
-{
-    return g_rangeLeadBias.load(std::memory_order_relaxed);
-}
-
-void SetIgnoreWalls(bool on)
-{
-    g_ignoreWalls.store(on, std::memory_order_relaxed);
-}
-
-bool IsIgnoreWalls()
-{
-    return g_ignoreWalls.load(std::memory_order_relaxed);
-}
-
-void SetReverseCultStaff(bool on)
-{
-    g_reverseCultStaff.store(on, std::memory_order_relaxed);
-}
-
-bool IsReverseCultStaff()
-{
-    return g_reverseCultStaff.load(std::memory_order_relaxed);
-}
-
-void SetOffsetColossusSword(bool on)
-{
-    g_offsetColossusSword.store(on, std::memory_order_relaxed);
-}
-
-bool IsOffsetColossusSword()
-{
-    return g_offsetColossusSword.load(std::memory_order_relaxed);
-}
-
-void SetShootWhileStealthed(bool on)
-{
-    g_shootWhileStealthed.store(on, std::memory_order_relaxed);
-}
-
-bool IsShootWhileStealthed()
-{
-    return g_shootWhileStealthed.load(std::memory_order_relaxed);
-}
-
-void OnLocalPlayerProjectileSpawn(void* projProps, bool isAbility, int32_t attackerObjId, uint32_t ownerObjId)
-{
-    if (isAbility || !projProps)
-        return;
-    if (!GameState::GetLocalPtr())
-        return;
-    const int32_t dk = ProjectileTracking::GetLocalPlayerObjectId();
-    const bool isPlayerShot = (dk != 0) && (attackerObjId == dk || static_cast<int32_t>(ownerObjId) == dk);
-    if (!isPlayerShot)
-        return;
-    g_lastLocalProjProps.store(projProps, std::memory_order_relaxed);
-    __try {
-        uint8_t* pp = reinterpret_cast<uint8_t*>(projProps);
-        g_lastLocalProjId.store(*reinterpret_cast<int32_t*>(pp + kOffProjId), std::memory_order_relaxed);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        g_lastLocalProjId.store(0, std::memory_order_relaxed);
-    }
-    UpdateAutoAimValues(GameState::GetLocalPtr());
-}
-
-bool HasTarget()
-{
-    return g_hasAimTarget.load(std::memory_order_relaxed);
-}
-
-void GetAimTarget(float& outX, float& outY)
-{
-    outX = g_aimTargetX.load(std::memory_order_relaxed);
-    outY = g_aimTargetY.load(std::memory_order_relaxed);
-}
-
-int32_t GetAimFocusEnemyId()
-{
-    return g_aimFocusEnemyId.load(std::memory_order_relaxed);
-}
-
-bool TryGetEnemyAimLeadSample(int32_t objectId, float& outX, float& outY, float& outVx, float& outVy)
-{
-    if (objectId == 0)
-        return false;
-    const auto it = g_aimVelMap.find(objectId);
-    if (it == g_aimVelMap.end())
-        return false;
-    outX  = it->second.x;
-    outY  = it->second.y;
-    outVx = it->second.vx;
-    outVy = it->second.vy;
-    return true;
-}
-
-float GetProjSpeedRaw()    { return g_playerProjSpeedRaw.load(std::memory_order_relaxed); }
-float GetProjLifetimeMs()  { return g_playerProjLifetimeMs.load(std::memory_order_relaxed); }
-float GetProjRangeTiles()  { return g_playerProjRangeTiles.load(std::memory_order_relaxed); }
-bool  IsProjRangeResolved(){ return g_playerProjRangeResolved.load(std::memory_order_relaxed); }
-
-void GetWeaponRangeDiag(float& outRangeTiles, uint32_t& outAttempts,
-                        uint32_t& outSuccesses, const char*& outLastError)
-{
-    outRangeTiles = g_playerProjRangeTiles.load(std::memory_order_relaxed);
-    outAttempts   = g_wrRefreshAttempts.load(std::memory_order_relaxed);
-    outSuccesses  = g_wrRefreshSuccesses.load(std::memory_order_relaxed);
-    outLastError  = g_wrLastError.load(std::memory_order_relaxed);
-}
-
-void SuspendForMs(uint64_t ms)
-{
-    const uint64_t deadline = GetTickCount64() + ms;
-    uint64_t cur = g_suspendUntilMs.load(std::memory_order_relaxed);
-    while (deadline > cur) {
-        if (g_suspendUntilMs.compare_exchange_weak(
-                cur, deadline,
-                std::memory_order_relaxed, std::memory_order_relaxed)) {
-            break;
-        }
-    }
-    g_hasAimTarget.store(false, std::memory_order_relaxed);
-    g_aimFocusEnemyId.store(0, std::memory_order_relaxed);
-}
-
-bool IsSuspended()
-{
-    const uint64_t deadline = g_suspendUntilMs.load(std::memory_order_relaxed);
-    return deadline != 0 && GetTickCount64() < deadline;
-}
-
-void SetEnemyNextTickOverlay(bool on)
-{
-    g_enemyNextTickOverlay.store(on, std::memory_order_relaxed);
-}
-
-bool IsEnemyNextTickOverlay()
-{
-    return g_enemyNextTickOverlay.load(std::memory_order_relaxed);
-}
-
-void EnumerateEnemyVelocities(EnemyVelCallback cb, void* user)
-{
-    if (!cb)
-        return;
-    for (const auto& kv : g_aimVelMap) {
-        const AimVelEntry& e = kv.second;
-        cb(kv.first, e.x, e.y, e.vx, e.vy, user);
-    }
-}
-
-void EnumerateLiveEnemies(EnemyScanCallback cb, void* user)
-{
-    EnumerateLiveEnemiesBody(cb, user);
-}
-
-static void* ResolveMethod(const char* className, const char* methodName, int paramCount, const char* /*label*/)
-{
-    Il2CppClass* klass = Resolver::GetClass("", className);
-    if (!klass)
-        return nullptr;
-    const MethodInfo* mi = il2cpp_class_get_method_from_name(klass, methodName, paramCount);
-    if (!mi || !mi->methodPointer)
-        return nullptr;
-    return reinterpret_cast<void*>(mi->methodPointer);
-}
-
 void Install()
 {
-    if (g_hooksInstalled)
-        return;
-
-    if (g_firstInstallTick == 0)
-        g_firstInstallTick = GetTickCount64();
-
-    g_csaTarget = ResolveMethod(kPlayerClassName, kCSAMethodName, kCSAParamCount, "CSA");
-    g_swaTarget = ResolveMethod(kShootClassName,  kSWAMethodName, kSWAParamCount, "SWA");
-    g_sspTarget = ResolveMethod(kShootClassName,  kSSPMethodName, kSSPParamCount, "SSP");
-
-    if (!g_csaTarget || !g_swaTarget || !g_sspTarget)
-        return;
-
-    static bool s_mhInitDone = false;
-    if (!s_mhInitDone) {
-        MH_STATUS initSt = MH_Initialize();
-        if (initSt != MH_OK && initSt != MH_ERROR_ALREADY_INITIALIZED)
-            return;
-        s_mhInitDone = true;
-    }
-
-    MH_STATUS s1 = MH_CreateHook(g_csaTarget,
-        reinterpret_cast<void*>(&ComputeShootAngleDetour),
-        reinterpret_cast<void**>(&g_ComputeShootAngleOriginal));
-    MH_STATUS s2 = MH_CreateHook(g_swaTarget,
-        reinterpret_cast<void*>(&ShootWithAngleDetour),
-        reinterpret_cast<void**>(&g_ShootWithAngleOriginal));
-    MH_STATUS s3 = MH_CreateHook(g_sspTarget,
-        reinterpret_cast<void*>(&SendShotPacketDetour),
-        reinterpret_cast<void**>(&g_SendShotPacketOriginal));
-
-    if (s1 != MH_OK || s2 != MH_OK || s3 != MH_OK)
-        return;
-
-    MH_STATUS e1 = MH_EnableHook(g_csaTarget);
-    MH_STATUS e2 = MH_EnableHook(g_swaTarget);
-    MH_STATUS e3 = MH_EnableHook(g_sspTarget);
-    (void)e1;
-    (void)e2;
-    (void)e3;
-
-    s_lastTickThrottleMs = 0;
-    s_tickLastPlayerPtr = nullptr;
-
-    // Clear diagnostic log on fresh install.
-    { std::ofstream f(kAimLogPath, std::ios::trunc); }
-    s_aimLogEntries = 0;
-    s_aimLogBuf.str(""); s_aimLogBuf.clear();
-
-    g_allowTick.store(true, std::memory_order_release);
-    g_hooksInstalled = true;
+    // Lazy installs — safe to call every tick; each guards itself
+    ProjectileTracking::Install();
+    AoeTracking::Install();
+    AimHooks::Install();
 }
 
 void Uninstall()
 {
-    if (!g_hooksInstalled)
-        return;
+    AimHooks::Uninstall();
+    s_hasTarget.store(false, std::memory_order_relaxed);
+    s_aimFocusId.store(0, std::memory_order_relaxed);
+    WeaponCalibrator::Reset();
+}
 
-    g_allowTick.store(false, std::memory_order_release);
-    g_enemyNextTickOverlay.store(false, std::memory_order_relaxed);
+void Tick()
+{
+    Install();
 
-    if (g_csaTarget) { MH_DisableHook(g_csaTarget); MH_RemoveHook(g_csaTarget); }
-    if (g_swaTarget) { MH_DisableHook(g_swaTarget); MH_RemoveHook(g_swaTarget); }
-    if (g_sspTarget) { MH_DisableHook(g_sspTarget); MH_RemoveHook(g_sspTarget); }
+    const ULONGLONG wall = GetTickCount64();
+    if (wall - s_lastThrottleMs < 8ULL) return;
+    s_lastThrottleMs = wall;
 
-    g_ComputeShootAngleOriginal = nullptr;
-    g_ShootWithAngleOriginal    = nullptr;
-    g_SendShotPacketOriginal    = nullptr;
-    g_csaTarget = g_swaTarget = g_sspTarget = nullptr;
-    g_hooksInstalled = false;
-    g_lastLocalProjProps.store(nullptr, std::memory_order_relaxed);
-    g_lastLocalProjId.store(0, std::memory_order_relaxed);
-    g_hasAimTarget.store(false, std::memory_order_relaxed);
-    g_aimVelMap.clear();
+    RunTick();
+}
+
+void SetEnabled(bool on) {
+    s_enabled.store(on, std::memory_order_relaxed);
+    if (!on) {
+        s_hasTarget.store(false, std::memory_order_relaxed);
+        AimHooks::SetTarget(false, 0.f, 0.f);
+    }
+}
+bool IsEnabled() { return s_enabled.load(std::memory_order_relaxed); }
+
+void SetAimMode(TargetSelector::Mode mode) {
+    const int raw = static_cast<int>(mode);
+    s_aimModeInt.store((raw < 0 || raw > 3) ? 0 : raw, std::memory_order_relaxed);
+}
+TargetSelector::Mode GetAimMode() {
+    return static_cast<TargetSelector::Mode>(s_aimModeInt.load(std::memory_order_relaxed));
+}
+
+void SetLockTarget(int32_t enemyId) {
+    s_lockedEnemyId.store(enemyId, std::memory_order_relaxed);
+    s_aimModeInt.store(static_cast<int>(TargetSelector::Mode::Locked), std::memory_order_relaxed);
+}
+
+void SetShootInvulnerable(bool on)   { s_shootInvulnerable.store(on, std::memory_order_relaxed); }
+bool IsShootInvulnerable()           { return s_shootInvulnerable.load(std::memory_order_relaxed); }
+
+void SetPrioritizeBosses(bool on)    { s_prioritizeBosses.store(on, std::memory_order_relaxed); }
+bool IsPrioritizeBosses()            { return s_prioritizeBosses.load(std::memory_order_relaxed); }
+
+void SetIgnoreWalls(bool on)         { s_ignoreWalls.store(on, std::memory_order_relaxed); }
+bool IsIgnoreWalls()                 { return s_ignoreWalls.load(std::memory_order_relaxed); }
+
+void SetShootWhileStealthed(bool on) { s_shootWhileStealthed.store(on, std::memory_order_relaxed); }
+bool IsShootWhileStealthed()         { return s_shootWhileStealthed.load(std::memory_order_relaxed); }
+
+void SetPhaseSkipTypes(const int32_t* types, int count) {
+    s_skipObjTypes = types;
+    s_skipObjCount = count;
+}
+
+void SetMouseBoundingEnabled(bool on)  { s_mouseBoundingEnabled.store(on, std::memory_order_relaxed); }
+bool IsMouseBoundingEnabled()          { return s_mouseBoundingEnabled.load(std::memory_order_relaxed); }
+void SetMouseBoundingRange(float t)    {
+    if (!std::isfinite(t) || t < 0.f) t = 0.f;
+    if (t > 200.f) t = 200.f;
+    s_mouseBoundingRange.store(t, std::memory_order_relaxed);
+}
+float GetMouseBoundingRange()          { return s_mouseBoundingRange.load(std::memory_order_relaxed); }
+
+void SetRangeLeadBias(float t)         {
+    if (!std::isfinite(t) || t < 0.f) t = 0.f;
+    if (t > 50.f) t = 50.f;
+    s_rangeLeadBias.store(t, std::memory_order_relaxed);
+}
+float GetRangeLeadBias()               { return s_rangeLeadBias.load(std::memory_order_relaxed); }
+
+void SetReverseCultStaff(bool on)    { s_reverseCultStaff.store(on, std::memory_order_relaxed); AimHooks::SetReverseCultStaff(on); }
+bool IsReverseCultStaff()            { return s_reverseCultStaff.load(std::memory_order_relaxed); }
+
+void SetOffsetColossusSword(bool on) { s_offsetColossus.store(on, std::memory_order_relaxed); AimHooks::SetOffsetColossusSword(on); }
+bool IsOffsetColossusSword()         { return s_offsetColossus.load(std::memory_order_relaxed); }
+
+bool    HasTarget()       { return s_hasTarget.load(std::memory_order_relaxed); }
+void    GetAimTarget(float& ox, float& oy) {
+    ox = s_aimX.load(std::memory_order_relaxed);
+    oy = s_aimY.load(std::memory_order_relaxed);
+}
+int32_t GetAimFocusEnemyId() { return s_aimFocusId.load(std::memory_order_relaxed); }
+
+const WeaponProfile& GetWeaponProfile() { return WeaponCalibrator::GetProfile(); }
+
+void OnLocalPlayerProjectileSpawn(void* projProps, bool isAbility,
+                                   int32_t attackerObjId, uint32_t ownerObjId)
+{
+    if (isAbility || !projProps) return;
+    if (!GameState::GetLocalPtr()) return;
+    int32_t dk = ProjectileTracking::GetLocalPlayerObjectId();
+    if (dk == 0) dk = EnemyTracker::GetLocalPlayerObjectId();
+    if (dk == 0 || (attackerObjId != dk && static_cast<int32_t>(ownerObjId) != dk)) return;
+    WeaponCalibrator::OnProjectileSpawn(projProps, GameState::GetLocalPtr());
+}
+
+void EnumerateLiveEnemies(EnemyScanCallback cb, void* user) {
+    if (!cb) return;
+    // Ensure a fresh snapshot — consumers (auto-dodge) may run with auto-aim off.
+    // EnemyTracker::Tick is self-throttled, so this is deduped against the aim path.
+    EnemyTracker::Tick();
+    struct Ctx { EnemyScanCallback cb; void* user; };
+    Ctx ctx{ cb, user };
+    EnemyTracker::Enumerate([](const EnemyTracker::Entry& e, void* u) {
+        auto* c = static_cast<Ctx*>(u);
+        c->cb(e.x, e.y, e.id, c->user);
+    }, &ctx);
 }
 
 } // namespace AutoAim

--- a/internal/src/features/combat/autoaim/AutoAim.h
+++ b/internal/src/features/combat/autoaim/AutoAim.h
@@ -1,107 +1,88 @@
 #pragma once
 
+#include "TargetSelector.h"
+#include "WeaponProfile.h"
 #include <cstdint>
 
+// AutoAim coordinator — public API consumed by FeatAutoAim UI and other features.
+// All heavy logic lives in EnemyTracker, TargetSelector, WeaponCalibrator, and AimHooks.
 namespace AutoAim {
-
-// Numeric values match Multitool registry `AutoAimMode` / ExaltKitGUI.SettingsControl:
-//   0 = closest to player, 1 = highest HP, 2 = closest to mouse.
-enum class AimMode : int {
-    ClosestToPlayer = 0,
-    HighestHP       = 1,
-    ClosestToMouse  = 2,
-};
 
 void Install();
 void Uninstall();
 
-// Called from D3D Present each frame (throttled ~8ms). Keeps world/dict reads off a background thread.
+// Called from D3D Present each frame (~8ms throttle).
 void Tick();
 
+// ── Master toggle ─────────────────────────────────────────────────────────────
 void SetEnabled(bool on);
 bool IsEnabled();
 
-void SetAimMode(AimMode mode);
-AimMode GetAimMode();
+// ── Aim mode ──────────────────────────────────────────────────────────────────
+void SetAimMode(TargetSelector::Mode mode);
+TargetSelector::Mode GetAimMode();
 
-// Multitool AutoAimShootInvulnerable / xrDriver targetInvulnerable. When true, invincible
-// enemies become valid targets (but still deprioritised below non-invulnerable candidates).
+// Lock onto a specific enemy by object ID (sets mode to Locked).
+// Pass -1 or call SetAimMode to clear the lock.
+void SetLockTarget(int32_t enemyId);
+
+// ── Targeting filters ─────────────────────────────────────────────────────────
 void SetShootInvulnerable(bool on);
 bool IsShootInvulnerable();
 
-// Multitool AutoAimFocusBoss / PrioritizeBosses. When true, quest/boss objectTypes
-// (kQuestObjectTypes) are prioritised as first-pass targets. If no boss is in range,
-// normal enemies become valid targets instead of being skipped entirely.
 void SetPrioritizeBosses(bool on);
 bool IsPrioritizeBosses();
 
-// xrDriver MouseBoundingEnabled + MouseBoundingRange (_DAT_18057a878 / _DAT_18057a874). Clamps
-// ClosestToMouse-mode candidate distance to this radius around the mouse world position.
+void SetIgnoreWalls(bool on);
+bool IsIgnoreWalls();
+
+void SetShootWhileStealthed(bool on);
+bool IsShootWhileStealthed();
+
+// Phase skip list: object types to exclude from all tiers regardless of invulnerability.
+// Pointer is borrowed; caller must keep it alive (static storage recommended).
+void SetPhaseSkipTypes(const int32_t* types, int count);
+
+// ── Mouse / range ─────────────────────────────────────────────────────────────
 void  SetMouseBoundingEnabled(bool on);
 bool  IsMouseBoundingEnabled();
 void  SetMouseBoundingRange(float tiles);
 float GetMouseBoundingRange();
 
-// Multitool AutoAimRangeLead. Extra tiles added on top of computed weapon range when deciding
-// whether a candidate is in aim range (starts facing/leading before shots can actually connect).
 void  SetRangeLeadBias(float tiles);
 float GetRangeLeadBias();
 
-// Multitool AutoAimIgnoreWalls. When true (default), skip wall-like targets (ObjectProperties.noHealthBar).
-void  SetIgnoreWalls(bool on);
-bool  IsIgnoreWalls();
+// ── Weapon-specific tweaks ────────────────────────────────────────────────────
+void SetReverseCultStaff(bool on);
+bool IsReverseCultStaff();
 
-// Multitool AutoAimReverseCultStaff — add π to aim for Staff of Unholy Sacrifice shots (proj id 0xB0EB).
-void  SetReverseCultStaff(bool on);
-bool  IsReverseCultStaff();
+void SetOffsetColossusSword(bool on);
+bool IsOffsetColossusSword();
 
-// Multitool AutoAimOffsetColossusSword — reserved for Sword of the Colossus (proj id 0xB106); offset TBD.
-void  SetOffsetColossusSword(bool on);
-bool  IsOffsetColossusSword();
-
-// Multitool AutoAimShootWhileStealthed. When false, auto-aim does not redirect while Invisible.
-void  SetShootWhileStealthed(bool on);
-bool  IsShootWhileStealthed();
-
-// DIA4A SpawnProjectile path: local non-ability weapon shots update lead speed (projProps+0x160).
-void OnLocalPlayerProjectileSpawn(void* projProps, bool isAbility, int32_t attackerObjId, uint32_t ownerObjId);
-
-bool HasTarget();
-void GetAimTarget(float& outX, float& outY);
-
-// Object id of the enemy auto-aim picked this tick (0 if none). Used for light spell leading.
+// ── State queries ─────────────────────────────────────────────────────────────
+bool    HasTarget();
+void    GetAimTarget(float& outX, float& outY);
 int32_t GetAimFocusEnemyId();
-// Last sampled position + velocity from the aim velocity map; false if unknown.
-// outVx/outVy are tiles per millisecond (matches Priest/Wizard spell lead: delta = v * ms).
-bool TryGetEnemyAimLeadSample(int32_t objectId, float& outX, float& outY, float& outVx, float& outVy);
 
-// Weapon stats read from projProps at last shot — updated by OnLocalPlayerProjectileSpawn.
-float GetProjSpeedRaw();      // raw int as float (divide by 10000 for tiles/ms)
-float GetProjLifetimeMs();    // normalized lifetime in ms
-float GetProjRangeTiles();    // tiles = (speed/10000) * lifetime_ms
-// True only once the passive refresh OR a fired shot has written a real
-// weapon range. When false the `GetProjRangeTiles()` value is a placeholder
-// default and callers should prefer their manual fallback range.
-bool  IsProjRangeResolved();
-// Diagnostics for the passive equipped-weapon range refresh.
-void  GetWeaponRangeDiag(float& outRangeTiles, uint32_t& outAttempts,
-                         uint32_t& outSuccesses, const char*& outLastError);
+const WeaponProfile& GetWeaponProfile();
 
-// Transient suspend (used by the planner during realm transitions to
-// pause aim while stale entity pointers from the old world drain).
-void SuspendForMs(uint64_t ms);
-bool IsSuspended();
+// ── Projectile spawn callback ─────────────────────────────────────────────────
+// SpawnProjectile path: call for local non-ability shots to calibrate weapon range.
+void OnLocalPlayerProjectileSpawn(void* projProps, bool isAbility,
+                                  int32_t attackerObjId, uint32_t ownerObjId);
 
-// When enabled, Tick() keeps per-enemy velocity (same data as auto-aim lead) even if aim is off.
-void SetEnemyNextTickOverlay(bool on);
-bool IsEnemyNextTickOverlay();
-
-using EnemyVelCallback = void (*)(int32_t id, float x, float y, float vx, float vy, void* user);
-void EnumerateEnemyVelocities(EnemyVelCallback cb, void* user);
-
-// Live enemy world positions from the same world-dict scan as auto-aim (no auto-aim toggle required).
-// Entity objectTypes listed in AutoAim.cpp (kIgnoredEnemyObjectTypes) are skipped — same filter as auto-aim.
-using EnemyScanCallback = void (*)(float x, float y, int32_t id, void* user);
+// ── Shared enemy enumeration (delegates to EnemyTracker) ──────────────────────
+// Used by auto-dodge to read live enemy positions. Triggers a (self-throttled)
+// EnemyTracker refresh, so it returns fresh data even when auto-aim is disabled.
+using EnemyScanCallback = void(*)(float x, float y, int32_t id, void* user);
 void EnumerateLiveEnemies(EnemyScanCallback cb, void* user);
+
+// ── Compatibility aliases for existing callers ────────────────────────────────
+// AimMode alias so FeatureRuntime etc. don't need updating.
+using AimMode = TargetSelector::Mode;
+
+// Proj-stat wrappers used by ZDodge and DangerPlanner.
+inline float GetProjRangeTiles()   { return GetWeaponProfile().rangeTiles; }
+inline bool  IsProjRangeResolved() { return GetWeaponProfile().isResolved; }
 
 } // namespace AutoAim

--- a/internal/src/features/combat/autoaim/FeatAutoAim.cpp
+++ b/internal/src/features/combat/autoaim/FeatAutoAim.cpp
@@ -4,28 +4,35 @@
 #include "ProjNoclip.h"
 #include "FeatureState.h"
 #include <imgui/imgui.h>
+#include <cstdio>
+#include <cstdlib>
 
 namespace CombatTAB {
 namespace FeatAutoAim {
 
-// Multitool registry AutoAimMode: 0 closest, 1 highest HP, 2 mouse (ExaltKitGUI.SettingsControl).
-static bool  s_aimEnabled           = false;
-static int   s_aimMode              = 0;
-static bool  s_noclipEnabled        = false;
-static bool  s_shootInvulnerable    = false;
-static bool  s_prioritizeBosses     = false;
-static bool  s_ignoreWalls          = true;
-static bool  s_reverseCultStaff     = true;
-static bool  s_offsetColossusSword  = false;
-static bool  s_shootWhileStealthed  = true;
-static bool  s_mouseBoundingOn      = true;
-static float s_mouseBoundingRange   = 2.f;
-static float s_rangeLeadBias        = 1.f;
+static bool  s_aimEnabled          = false;
+static int   s_aimMode             = 0;
+static bool  s_noclipEnabled       = false;
+static bool  s_shootInvulnerable   = false;
+static bool  s_prioritizeBosses    = false;
+static bool  s_ignoreWalls         = true;
+static bool  s_reverseCultStaff    = true;
+static bool  s_offsetColossusSword = false;
+static bool  s_shootWhileStealthed = true;
+static bool  s_mouseBoundingOn     = true;
+static float s_mouseBoundingRange  = 2.f;
+static float s_rangeLeadBias       = 1.f;
+
+// Phase-skip list — editable in the UI; stored as a fixed-capacity array of raw ints.
+static constexpr int kMaxSkipTypes = 16;
+static int32_t s_skipTypes[kMaxSkipTypes] = {};
+static int     s_skipCount = 0;
+static char    s_skipInputBuf[32] = {};
 
 void Tick(bool /*menuOpen*/)
 {
-    s_aimEnabled    = FeatureState::GetAutoAimEnabled();
-    s_aimMode       = FeatureState::GetAutoAimMode();
+    s_aimEnabled   = FeatureState::GetAutoAimEnabled();
+    s_aimMode      = FeatureState::GetAutoAimMode();
     s_noclipEnabled = ProjNoclip::IsEnabled();
 
     s_shootInvulnerable   = AutoAim::IsShootInvulnerable();
@@ -51,68 +58,115 @@ void Render()
         FeatureState::SetAutoAimEnabled(s_aimEnabled);
 
     ImGui::Spacing();
-    ImGui::TextDisabled("Aim mode (Multitool AutoAimMode)");
+    ImGui::TextDisabled("Aim mode");
+
     if (ImGui::RadioButton("Closest to player##aaMode0", s_aimMode == 0)) {
-        s_aimMode = 0;
-        FeatureState::SetAutoAimMode(0);
-        AutoAim::SetAimMode(AutoAim::AimMode::ClosestToPlayer);
+        s_aimMode = 0; FeatureState::SetAutoAimMode(0);
+        AutoAim::SetAimMode(TargetSelector::Mode::ClosestToPlayer);
     }
     if (ImGui::RadioButton("Highest HP##aaMode1", s_aimMode == 1)) {
-        s_aimMode = 1;
-        FeatureState::SetAutoAimMode(1);
-        AutoAim::SetAimMode(AutoAim::AimMode::HighestHP);
+        s_aimMode = 1; FeatureState::SetAutoAimMode(1);
+        AutoAim::SetAimMode(TargetSelector::Mode::HighestHP);
     }
     if (ImGui::RadioButton("Closest to mouse##aaMode2", s_aimMode == 2)) {
-        s_aimMode = 2;
-        FeatureState::SetAutoAimMode(2);
-        AutoAim::SetAimMode(AutoAim::AimMode::ClosestToMouse);
+        s_aimMode = 2; FeatureState::SetAutoAimMode(2);
+        AutoAim::SetAimMode(TargetSelector::Mode::ClosestToMouse);
+    }
+    if (ImGui::RadioButton("Locked target##aaMode3", s_aimMode == 3)) {
+        s_aimMode = 3; FeatureState::SetAutoAimMode(3);
+        AutoAim::SetAimMode(TargetSelector::Mode::Locked);
+    }
+    if (s_aimMode == 3) {
+        ImGui::Indent();
+        const int32_t lockedId = AutoAim::GetAimFocusEnemyId();
+        if (lockedId > 0)
+            ImGui::TextColored(ImVec4(0.4f, 1.f, 0.5f, 1.f), "Locked on id %d", lockedId);
+        else
+            ImGui::TextDisabled("No lock — aim at an enemy while in another mode first");
+        if (ImGui::Button("Lock current target##aaLock")) {
+            const int32_t cur = AutoAim::GetAimFocusEnemyId();
+            if (cur > 0) AutoAim::SetLockTarget(cur);
+        }
+        if (ImGui::Button("Clear lock##aaClearLock")) {
+            AutoAim::SetLockTarget(-1);
+            AutoAim::SetAimMode(TargetSelector::Mode::ClosestToPlayer);
+            s_aimMode = 0;
+        }
+        ImGui::Unindent();
     }
 
     ImGui::Spacing();
     ImGui::TextDisabled("Targeting filters");
+
     if (ImGui::Checkbox("Shoot invulnerable##aaShootInv", &s_shootInvulnerable))
         AutoAim::SetShootInvulnerable(s_shootInvulnerable);
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::SameLine(); ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
         ImGui::SetTooltip("Aims at invulnerable enemies (XML <Invincible/>). They stay below\nregular enemies in priority so non-invuln targets are still picked first.");
 
     if (ImGui::Checkbox("Prioritize bosses##aaBossOnly", &s_prioritizeBosses))
         AutoAim::SetPrioritizeBosses(s_prioritizeBosses);
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::SameLine(); ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Quest/boss targets are aimed at first. If no boss is in range,\nregular enemies become valid targets (they are no longer skipped).");
+        ImGui::SetTooltip("Quest/boss targets are aimed at first. If no boss is in range,\nregular enemies become valid targets.");
 
     if (ImGui::Checkbox("Ignore walls / no-HP-bar##aaIgnoreWalls", &s_ignoreWalls))
         AutoAim::SetIgnoreWalls(s_ignoreWalls);
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::SameLine(); ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Multitool AutoAimIgnoreWalls: skip destructible walls and similar\n(ObjectProperties.noHealthBar).");
+        ImGui::SetTooltip("Skip destructible walls and similar (ObjectProperties.noHealthBar).");
 
     ImGui::Spacing();
-    ImGui::TextDisabled("Weapon-specific (Multitool)");
+    ImGui::TextDisabled("Phase skip (e.g. O3 invulnerable phases)");
+    ImGui::TextWrapped("Object type IDs skipped regardless of invulnerability flags.");
+
+    for (int i = 0; i < s_skipCount; ++i) {
+        char lbl[32];
+        snprintf(lbl, sizeof(lbl), "%d##skip%d", s_skipTypes[i], i);
+        ImGui::Bullet(); ImGui::SameLine();
+        ImGui::Text("%d", s_skipTypes[i]); ImGui::SameLine();
+        snprintf(lbl, sizeof(lbl), "X##skipRm%d", i);
+        if (ImGui::SmallButton(lbl)) {
+            for (int j = i; j < s_skipCount - 1; ++j) s_skipTypes[j] = s_skipTypes[j + 1];
+            --s_skipCount;
+            AutoAim::SetPhaseSkipTypes(s_skipCount > 0 ? s_skipTypes : nullptr, s_skipCount);
+        }
+    }
+    if (s_skipCount < kMaxSkipTypes) {
+        ImGui::PushItemWidth(120.f);
+        ImGui::InputText("##skipInput", s_skipInputBuf, sizeof(s_skipInputBuf),
+                         ImGuiInputTextFlags_CharsDecimal);
+        ImGui::PopItemWidth();
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Add##skipAdd")) {
+            const int32_t v = static_cast<int32_t>(atoi(s_skipInputBuf));
+            if (v > 0) {
+                s_skipTypes[s_skipCount++] = v;
+                AutoAim::SetPhaseSkipTypes(s_skipTypes, s_skipCount);
+                s_skipInputBuf[0] = '\0';
+            }
+        }
+    }
+
+    ImGui::Spacing();
+    ImGui::TextDisabled("Weapon-specific");
     if (ImGui::Checkbox("Reverse Cult Staff##aaRevCult", &s_reverseCultStaff))
         AutoAim::SetReverseCultStaff(s_reverseCultStaff);
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::SameLine(); ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
         ImGui::SetTooltip("Staff of Unholy Sacrifice: add 180\xc2\xb0 to aim (Cultist Fire Shot).");
 
     if (ImGui::Checkbox("Offset Colossus Sword##aaColOff", &s_offsetColossusSword))
         AutoAim::SetOffsetColossusSword(s_offsetColossusSword);
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::SameLine(); ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Sword of the Colossus: reserved \xe2\x80\x94 exact offset not yet extracted from Multitool DLL.");
+        ImGui::SetTooltip("Sword of the Colossus: reserved \xe2\x80\x94 exact offset not yet extracted.");
 
     if (ImGui::Checkbox("Shoot while stealthed##aaStealthShoot", &s_shootWhileStealthed))
         AutoAim::SetShootWhileStealthed(s_shootWhileStealthed);
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::SameLine(); ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
-        ImGui::SetTooltip("Multitool AutoAimShootWhileStealthed: when off, auto-aim does nothing while Invisible.");
+        ImGui::SetTooltip("When off, auto-aim does nothing while Invisible.");
 
     ImGui::Spacing();
     ImGui::TextDisabled("Mouse distance (closest-to-mouse)");
@@ -120,7 +174,7 @@ void Render()
         AutoAim::SetMouseBoundingEnabled(s_mouseBoundingOn);
     ImGui::BeginDisabled(!s_mouseBoundingOn || s_aimMode != 2);
     ImGui::PushItemWidth(180.f);
-    if (ImGui::SliderFloat("AutoAimMouseDist (tiles)##aaMouseBoundR", &s_mouseBoundingRange, 1.f, 15.f, "%.2f"))
+    if (ImGui::SliderFloat("Mouse radius (tiles)##aaMouseBoundR", &s_mouseBoundingRange, 1.f, 15.f, "%.2f"))
         AutoAim::SetMouseBoundingRange(s_mouseBoundingRange);
     ImGui::PopItemWidth();
     ImGui::EndDisabled();
@@ -128,40 +182,33 @@ void Render()
     ImGui::Spacing();
     ImGui::TextDisabled("Range lead bias");
     ImGui::PushItemWidth(180.f);
-    if (ImGui::SliderFloat("AutoAimRangeLead (tiles)##aaRangeLead", &s_rangeLeadBias, 0.f, 5.f, "%.2f"))
+    if (ImGui::SliderFloat("Lead bias (tiles)##aaRangeLead", &s_rangeLeadBias, 0.f, 5.f, "%.2f"))
         AutoAim::SetRangeLeadBias(s_rangeLeadBias);
     ImGui::PopItemWidth();
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::SameLine(); ImGui::TextDisabled("(?)");
     if (ImGui::IsItemHovered())
         ImGui::SetTooltip("Extra tiles added to weapon range for aim decisions.\nStarts facing/leading enemies before your shots can connect.");
 
     if (s_aimEnabled) {
         ImGui::Indent();
-
         ImGui::Spacing();
         if (AutoAim::HasTarget()) {
             float tx = 0.f, ty = 0.f;
             AutoAim::GetAimTarget(tx, ty);
             ImGui::TextColored(ImVec4(0.4f, 1.f, 0.5f, 1.f),
-                "Target: %.2f, %.2f  (id %d)", static_cast<double>(tx), static_cast<double>(ty),
+                "Target: %.2f, %.2f  (id %d)",
+                static_cast<double>(tx), static_cast<double>(ty),
                 AutoAim::GetAimFocusEnemyId());
         } else {
             ImGui::TextDisabled("No target");
         }
-
-        {
-            const float spd   = AutoAim::GetProjSpeedRaw();
-            const float life  = AutoAim::GetProjLifetimeMs();
-            const float range = AutoAim::GetProjRangeTiles();
-            if (spd > 0.f || life > 0.f) {
-                ImGui::TextDisabled("Proj: speed %.0f  life %.0fms  range %.2f tiles",
-                    static_cast<double>(spd),
-                    static_cast<double>(life),
-                    static_cast<double>(range));
-            }
+        const WeaponProfile& wp = AutoAim::GetWeaponProfile();
+        if (wp.speedRaw > 0.f || wp.lifetimeMs > 0.f) {
+            ImGui::TextDisabled("Proj: speed %.0f  life %.0fms  range %.2f tiles",
+                static_cast<double>(wp.speedRaw),
+                static_cast<double>(wp.lifetimeMs),
+                static_cast<double>(wp.rangeTiles));
         }
-
         ImGui::Unindent();
     }
 
@@ -176,19 +223,17 @@ void Render()
         "Matches multitool WeaponModsProjectileNoclip behaviour exactly.");
     ImGui::Spacing();
 
-    if (!ProjNoclip::IsInstalled()) {
+    if (!ProjNoclip::IsInstalled())
         ImGui::TextColored(ImVec4(1.f, 0.6f, 0.2f, 1.f),
             "Hooks not installed \xe2\x80\x94 waiting for IL2CPP class resolution.");
-    }
 
     if (ImGui::Checkbox("Enable proj noclip##pnEnable", &s_noclipEnabled))
         ProjNoclip::SetEnabled(s_noclipEnabled);
 
-    if (ProjNoclip::IsInstalled() && ProjNoclip::IsEnabled()) {
+    if (ProjNoclip::IsInstalled() && ProjNoclip::IsEnabled())
         ImGui::TextColored(ImVec4(0.4f, 1.f, 0.5f, 1.f), "Active");
-    } else if (ProjNoclip::IsInstalled()) {
+    else if (ProjNoclip::IsInstalled())
         ImGui::TextDisabled("Inactive");
-    }
 }
 
 } // namespace FeatAutoAim

--- a/internal/src/features/combat/autoaim/TargetSelector.cpp
+++ b/internal/src/features/combat/autoaim/TargetSelector.cpp
@@ -1,0 +1,183 @@
+#include "pch-il2cpp.h"
+
+#include "TargetSelector.h"
+#include "AimMath.h"
+#include "features/combat/enemytracker/EnemyTracker.h"
+#include "gui/tabs/TestTAB.h"
+
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+// ── Object type helpers (mirrors EnemyTracker constants, kept local to avoid coupling) ──
+static constexpr int32_t kQuestTypes[] = {
+    1337, 2048, 2340, 2349, 3448, 3449, 3452, 3613, 3622, 4312,
+    4324, 4325, 4326, 5943, 8200, 24092, 24327, 24351, 24363, 24587,
+    29003, 29021, 29039, 29341, 29342, 29723, 29764, 30026, 45104, 45371,
+    45076, 28618, 28619, 32751, 29793
+};
+static constexpr int32_t kWhitelistedTypes[] = { 31104 };
+static constexpr int32_t kFallbackTypes[]    = { 2928 };
+
+static bool IsQuestType(int32_t t) {
+    for (int32_t q : kQuestTypes) if (q == t) return true;
+    return false;
+}
+static bool IsWhitelistedType(int32_t t) {
+    for (int32_t v : kWhitelistedTypes) if (v == t) return true;
+    return false;
+}
+static bool IsFallbackType(int32_t t) {
+    for (int32_t v : kFallbackTypes) if (v == t) return true;
+    return false;
+}
+
+struct TierState {
+    float   bestDist = 0.f;
+    int32_t bestHp   = -1;
+    float   bestX = 0.f, bestY = 0.f;
+    float   bestVx = 0.f, bestVy = 0.f;
+    int32_t bestId = 0;
+    int32_t bestObjType = 0;
+    bool    found = false;
+};
+
+static void TierUpdate(TierState& tier, bool useHighestHp,
+                       float distSq, int32_t hp,
+                       float x, float y, float vx, float vy,
+                       int32_t id, int32_t objType)
+{
+    bool better = false;
+    if (!tier.found) {
+        better = true;
+    } else if (useHighestHp) {
+        better = hp > tier.bestHp || (hp == tier.bestHp && distSq < tier.bestDist);
+    } else {
+        better = distSq < tier.bestDist;
+    }
+    if (!better) return;
+    tier.found = true; tier.bestDist = distSq; tier.bestHp = hp;
+    tier.bestX = x; tier.bestY = y; tier.bestVx = vx; tier.bestVy = vy;
+    tier.bestId = id; tier.bestObjType = objType;
+}
+
+} // namespace
+
+namespace TargetSelector {
+
+Result Select(const Config& cfg,
+              float playerX, float playerY,
+              float mouseX,  float mouseY,
+              const WeaponProfile& weapon)
+{
+    const std::vector<EnemyTracker::Entry>& snap = EnemyTracker::GetSnapshot();
+
+    // ── Locked mode: bypass all tier logic ──────────────────────────────────
+    if (cfg.mode == Mode::Locked && cfg.lockedEnemyId >= 0) {
+        for (const EnemyTracker::Entry& e : snap) {
+            if (e.id != cfg.lockedEnemyId) continue;
+            if (cfg.ignoreWalls && !e.hasHealthBar) break;
+            if (e.isInvulnerable && !cfg.shootInvulnerable) break;
+
+            Result r;
+            r.found   = true;
+            r.enemyId = e.id;
+            r.objType = e.objType;
+
+            const float vxTps = e.vx * 1000.f, vyTps = e.vy * 1000.f;
+            const float spd      = (weapon.avgSpeedTps > 0.1f) ? weapon.avgSpeedTps : 10.f;
+            const float maxLead  = (weapon.lifetimeMs  > 0.f)  ? weapon.lifetimeMs / 1000.f : 2.f;
+            if (vxTps != 0.f || vyTps != 0.f)
+                AimMath::QuadraticIntercept(playerX, playerY, e.x, e.y, vxTps, vyTps, spd, r.aimX, r.aimY, maxLead);
+            else { r.aimX = e.x; r.aimY = e.y; }
+            return r;
+        }
+        // Lock target gone/invalid — fall through to normal selection
+    }
+
+    // ── Reference point and range ────────────────────────────────────────────
+    const bool useMouseRef  = (cfg.mode == Mode::ClosestToMouse);
+    const bool useHighestHp = (cfg.mode == Mode::HighestHP);
+
+    float refX = playerX, refY = playerY;
+    if (useMouseRef) {
+        const float mx = TestTAB::GetMouseWorldX();
+        const float my = TestTAB::GetMouseWorldY();
+        if (mx != 0.f || my != 0.f) { refX = mx; refY = my; }
+    }
+
+    const float weaponRange = (weapon.rangeTiles > 2.f) ? weapon.rangeTiles : 15.f;
+    float maxRange = weaponRange + cfg.rangeLeadBias;
+    if (useMouseRef && cfg.mouseBoundingEnabled && cfg.mouseBoundingRange > 0.f
+        && cfg.mouseBoundingRange < maxRange)
+        maxRange = cfg.mouseBoundingRange;
+    const float maxRangeSq = maxRange * maxRange;
+
+    // ── Four-tier accumulation ───────────────────────────────────────────────
+    TierState quest, normal, fallback, invuln;
+
+    for (const EnemyTracker::Entry& e : snap) {
+        // Phase-skip filter
+        for (int i = 0; i < cfg.skipObjCount; ++i)
+            if (e.objType == cfg.skipObjTypes[i]) goto next_entry;
+
+        // Soft filters
+        if (cfg.ignoreWalls && !e.hasHealthBar) goto next_entry;
+        if (e.isInvulnerable && !cfg.shootInvulnerable) goto next_entry;
+
+        {
+            const float dx = e.x - refX, dy = e.y - refY;
+            const float distSq = dx * dx + dy * dy;
+            if (distSq > maxRangeSq) goto next_entry;
+
+            const bool isQuest      = IsQuestType(e.objType);
+            const bool whitelisted  = IsWhitelistedType(e.objType);
+            const bool isFallback   = IsFallbackType(e.objType);
+
+            if (cfg.prioritizeBosses && isQuest && !whitelisted) {
+                TierUpdate(quest, useHighestHp, distSq, e.hp, e.x, e.y, e.vx, e.vy, e.id, e.objType);
+            } else if (e.isInvulnerable) {
+                // Only reachable when shootInvulnerable == true (filtered above otherwise)
+                TierUpdate(invuln, useHighestHp, distSq, e.hp, e.x, e.y, e.vx, e.vy, e.id, e.objType);
+            } else if (isFallback) {
+                TierUpdate(fallback, useHighestHp, distSq, e.hp, e.x, e.y, e.vx, e.vy, e.id, e.objType);
+            } else {
+                // Normal tier: non-quest, non-fallback, non-invuln, and
+                // whitelisted-quest or prioritizeBosses-off quest entities
+                TierUpdate(normal, useHighestHp, distSq, e.hp, e.x, e.y, e.vx, e.vy, e.id, e.objType);
+            }
+        }
+        next_entry:;
+    }
+
+    // ── Priority resolution: quest > normal > fallback > invuln ──────────────
+    const TierState* winner = nullptr;
+    if (quest.found)                          winner = &quest;
+    else if (normal.found)                    winner = &normal;
+    else if (fallback.found)                  winner = &fallback;
+    else if (invuln.found)                    winner = &invuln;
+
+    if (!winner) return {};
+
+    Result r;
+    r.found   = true;
+    r.enemyId = winner->bestId;
+    r.objType = winner->bestObjType;
+
+    // Apply lead prediction
+    const float vxTps   = winner->bestVx * 1000.f;
+    const float vyTps   = winner->bestVy * 1000.f;
+    const float spd     = (weapon.avgSpeedTps > 0.1f) ? weapon.avgSpeedTps : 10.f;
+    const float maxLead = (weapon.lifetimeMs  > 0.f)  ? weapon.lifetimeMs / 1000.f : 2.f;
+    if (vxTps != 0.f || vyTps != 0.f)
+        AimMath::QuadraticIntercept(playerX, playerY,
+                                    winner->bestX, winner->bestY,
+                                    vxTps, vyTps, spd,
+                                    r.aimX, r.aimY, maxLead);
+    else { r.aimX = winner->bestX; r.aimY = winner->bestY; }
+
+    return r;
+}
+
+} // namespace TargetSelector

--- a/internal/src/features/combat/autoaim/TargetSelector.h
+++ b/internal/src/features/combat/autoaim/TargetSelector.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "WeaponProfile.h"
+#include <cstdint>
+
+namespace TargetSelector {
+
+enum class Mode : int {
+    ClosestToPlayer = 0,
+    HighestHP       = 1,
+    ClosestToMouse  = 2,
+    Locked          = 3, // Track a specific enemy by ID; falls back to ClosestToPlayer if it dies
+};
+
+struct Config {
+    Mode           mode                 = Mode::ClosestToPlayer;
+    bool           shootInvulnerable    = false;
+    bool           prioritizeBosses     = true;
+    bool           ignoreWalls          = true;  // skip noHealthBar entities
+    float          rangeLeadBias        = 1.0f;  // extra tiles past weapon range
+    bool           mouseBoundingEnabled = false;
+    float          mouseBoundingRange   = 8.0f;
+    int32_t        lockedEnemyId        = -1;    // used when mode == Locked
+    const int32_t* skipObjTypes         = nullptr; // optional phase-skip list
+    int            skipObjCount         = 0;
+};
+
+struct Result {
+    bool    found   = false;
+    float   aimX    = 0.f;
+    float   aimY    = 0.f;
+    int32_t enemyId = -1;
+    int32_t objType = 0;
+};
+
+// playerX/Y and mouseX/Y in world-space tiles.
+// Reads the current EnemyTracker snapshot — call after EnemyTracker::Tick().
+Result Select(const Config& cfg,
+              float playerX, float playerY,
+              float mouseX,  float mouseY,
+              const WeaponProfile& weapon);
+
+} // namespace TargetSelector

--- a/internal/src/features/combat/autoaim/WeaponProfile.cpp
+++ b/internal/src/features/combat/autoaim/WeaponProfile.cpp
@@ -1,0 +1,149 @@
+#include "pch-il2cpp.h"
+
+#include "WeaponProfile.h"
+#include "AimMath.h"
+#include "RuntimeOffsets.h"
+#include "ProjectileTracking.h"
+
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+// Player character projectile tuning fields (RE'd offsets, not yet in RuntimeOffsets)
+static constexpr uint32_t kOffCharSpeedMul    = 0x188;
+static constexpr uint32_t kOffCharLifetimeMul = 0x18C;
+static constexpr uint32_t kOffCharRangeMul    = 0x6B8;
+static constexpr uint32_t kOffProjId          = 0x15C;
+
+static inline bool AddrOk(const void* p) {
+    const uintptr_t a = reinterpret_cast<uintptr_t>(p);
+    return a > 0x10000 && a < 0x7FFFFFFFFFFFULL;
+}
+
+static std::atomic<void*> s_projProps{ nullptr };
+static WeaponProfile      s_profile;
+
+static bool ReadPlayerTuners(void* local, float& outSpeedMul, float& outLifetimeMul, float& outRangeMul)
+{
+    if (!AddrOk(local)) return false;
+    __try {
+        uint8_t* p = reinterpret_cast<uint8_t*>(local);
+        outSpeedMul    = *reinterpret_cast<float*>(p + kOffCharSpeedMul);
+        outLifetimeMul = *reinterpret_cast<float*>(p + kOffCharLifetimeMul);
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+
+    outRangeMul = 1.f;
+    __try {
+        outRangeMul = *reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(local) + kOffCharRangeMul);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+
+    auto clamp1 = [](float v) { return (std::isfinite(v) && v > 0.f && v < 100.f) ? v : 1.f; };
+    outSpeedMul    = clamp1(outSpeedMul);
+    outLifetimeMul = clamp1(outLifetimeMul);
+    outRangeMul    = clamp1(outRangeMul);
+    return true;
+}
+
+static void Recalculate(void* local)
+{
+    void* pp = s_projProps.load(std::memory_order_relaxed);
+    if (!AddrOk(pp) || !AddrOk(local))
+        return;
+
+    float speedMul = 1.f, lifetimeMul = 1.f, rangeMul = 1.f;
+    if (!ReadPlayerTuners(local, speedMul, lifetimeMul, rangeMul))
+        return;
+
+    __try {
+        uint8_t* p = reinterpret_cast<uint8_t*>(pp);
+
+        const bool isParam      = *reinterpret_cast<bool*>(p + RuntimeOffsets::PP_IsParametric);
+        const int32_t rawSpeedI = *reinterpret_cast<int32_t*>(p + RuntimeOffsets::PP_Speed);
+        const float rawLife     = *reinterpret_cast<float*>(p + RuntimeOffsets::PP_Lifetime);
+        const float mag         = *reinterpret_cast<float*>(p + RuntimeOffsets::PP_Magnitude);
+
+        // Check parametric FIRST — swords/daggers/other fixed-arc weapons store
+        // PP_Speed = 0 (unused), which would fail the speed validation below.
+        if (isParam) {
+            if (!(std::isfinite(mag) && mag > 0.f)) return;
+            float rangeTiles = mag * speedMul;
+            if (rangeMul >= 0.5f && rangeMul <= 10.f)
+                rangeTiles *= rangeMul;
+            s_profile.speedRaw    = 0.f;
+            s_profile.lifetimeMs  = 0.f;
+            s_profile.rangeTiles  = rangeTiles;
+            s_profile.avgSpeedTps = 200.f;
+            s_profile.isResolved  = true;
+            return;
+        }
+
+        // Standard speed+lifetime projectile path.
+        // Lower bound is 0 (not 100) — melee weapons like swords store speed == 100
+        // (0.01 tiles/ms), which a <=100 guard would wrongly reject.
+        if (rawSpeedI <= 0 || rawSpeedI >= 500000) return;
+
+        const float rawSpeed   = static_cast<float>(rawSpeedI);
+        const float lifetimeMs = ProjectileTracking::NormalizeProjectileLifetimeMs(rawLife) * lifetimeMul;
+        if (!(lifetimeMs > 1.f) || !std::isfinite(lifetimeMs)) return;
+
+        float rangeTiles = AimMath::IntegratedProjectileDistance(p, lifetimeMs, speedMul, rawSpeed);
+        if (!(rangeTiles > 0.f) || !std::isfinite(rangeTiles)) return;
+        if (rangeMul >= 0.5f && rangeMul <= 10.f)
+            rangeTiles *= rangeMul;
+
+        float avgSpeedTps = (rangeTiles / lifetimeMs) * 1000.f;
+        if (!(avgSpeedTps > 0.01f) || !std::isfinite(avgSpeedTps))
+            avgSpeedTps = (rawSpeed / 10000.f) * speedMul * 1000.f;
+
+        s_profile.speedRaw    = rawSpeed;
+        s_profile.lifetimeMs  = lifetimeMs;
+        s_profile.rangeTiles  = rangeTiles;
+        s_profile.avgSpeedTps = avgSpeedTps;
+        s_profile.isResolved  = true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+    }
+}
+
+} // namespace
+
+namespace WeaponCalibrator {
+
+void OnProjectileSpawn(void* projProps, void* localPlayer)
+{
+    if (!projProps) return;
+    s_projProps.store(projProps, std::memory_order_relaxed);
+
+    // Read projId immediately while the pointer is hot.
+    __try {
+        s_profile.projId = *reinterpret_cast<int32_t*>(
+            reinterpret_cast<uint8_t*>(projProps) + kOffProjId);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        s_profile.projId = 0;
+    }
+
+    // Calibrate immediately — projProps is a managed IL2CPP object that may be
+    // collected or reused before the next render tick, so we must read it now.
+    Recalculate(localPlayer);
+}
+
+void Tick(void* localPlayer)
+{
+    // Re-read player multipliers each frame (speed/lifetime buffs can change).
+    // projProps is already cached; only re-runs Recalculate, which is fast.
+    Recalculate(localPlayer);
+}
+
+const WeaponProfile& GetProfile()
+{
+    return s_profile;
+}
+
+void Reset()
+{
+    s_projProps.store(nullptr, std::memory_order_relaxed);
+    s_profile = WeaponProfile{};
+}
+
+} // namespace WeaponCalibrator

--- a/internal/src/features/combat/autoaim/WeaponProfile.h
+++ b/internal/src/features/combat/autoaim/WeaponProfile.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+// Calibrated weapon profile derived from the last fired projectile.
+// Populated by WeaponCalibrator::OnProjectileSpawn and refreshed each tick
+// to pick up current player speed/lifetime multipliers.
+struct WeaponProfile {
+    float   speedRaw    = 0.f;   // raw int as float (divide by 10000 for tiles/ms)
+    float   lifetimeMs  = 0.f;   // post-multiplier lifetime
+    float   rangeTiles  = 15.f;  // effective range (placeholder until resolved)
+    float   avgSpeedTps = 10.f;  // average speed tiles/sec, used for QuadraticIntercept
+    int32_t projId      = 0;     // projProps objectType id (for weapon-specific tweaks)
+    bool    isResolved  = false; // true once calibrated from real projProps data
+};
+
+namespace WeaponCalibrator {
+
+// Call when the local player fires a non-ability shot.
+// localPlayer must be supplied so calibration can run immediately while projProps
+// is still valid (the managed object may be GC'd before the next render tick).
+void OnProjectileSpawn(void* projProps, void* localPlayer);
+
+// Call once per frame with the current local player pointer.
+// Re-reads player speed/lifetime/range multipliers for the cached projProps.
+void Tick(void* localPlayer);
+
+const WeaponProfile& GetProfile();
+
+// Reset on realm transition so stale range data doesn't carry forward.
+void Reset();
+
+} // namespace WeaponCalibrator

--- a/internal/src/features/combat/enemytracker/EnemyTracker.cpp
+++ b/internal/src/features/combat/enemytracker/EnemyTracker.cpp
@@ -1,0 +1,333 @@
+#include "pch-il2cpp.h"
+
+#include "EnemyTracker.h"
+#include "GameState.h"
+#include "RuntimeOffsets.h"
+
+#include <Windows.h>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+// ── Offset aliases ───────────────────────────────────────────────────────────
+static const uint32_t& kOffPosX          = RuntimeOffsets::PosX;
+static const uint32_t& kOffPosY          = RuntimeOffsets::PosY;
+static const uint32_t& kOffHp            = RuntimeOffsets::HP;
+static const uint32_t& kOffMaxHp         = RuntimeOffsets::MaxHP;
+static const uint32_t& kOffObjProps      = RuntimeOffsets::ObjProps;
+static const uint32_t& kOffOpIsEnemy     = RuntimeOffsets::OP_IsEnemy;
+static const uint32_t& kOffOpNoHealthBar = RuntimeOffsets::OP_NoHealthBar;
+static const uint32_t& kOffOpInvincElem  = RuntimeOffsets::OP_InvincibleElem;
+static const uint32_t& kOffObjType       = RuntimeOffsets::ObjType;
+static const uint32_t& kOffWmDict        = RuntimeOffsets::WM_AllDict;
+
+// IL2CPP Dictionary<int,T> layout constants
+constexpr uint32_t kOffDictEnt  = 0x18;
+constexpr uint32_t kOffDictCnt  = 0x20;
+constexpr uint32_t kOffArrMax   = 0x18;
+constexpr uint32_t kOffArrData  = 0x20;
+constexpr int      kEntryStride = 24;
+
+// ── Object type lists ────────────────────────────────────────────────────────
+// Non-enemy entity types to reject outright, and whitelisted types that bypass
+// the maxHp==200 decoy heuristic. Quest/fallback tiering lives in TargetSelector.
+static constexpr int32_t kIgnoredTypes[]     = { 28491 };
+static constexpr int32_t kWhitelistedTypes[] = { 31104 };
+
+static bool IsIgnoredType(int32_t t) {
+    for (int32_t v : kIgnoredTypes) if (v == t) return true;
+    return false;
+}
+static bool IsWhitelistedType(int32_t t) {
+    for (int32_t v : kWhitelistedTypes) if (v == t) return true;
+    return false;
+}
+
+static inline bool AddrOk(const void* p) {
+    const uintptr_t a = reinterpret_cast<uintptr_t>(p);
+    return a > 0x10000 && a < 0x7FFFFFFFFFFFULL;
+}
+
+// ── Velocity tracking ────────────────────────────────────────────────────────
+struct VelEntry {
+    float     x = 0.f, y = 0.f;
+    ULONGLONG t = 0;
+    float     vx = 0.f, vy = 0.f;
+};
+
+static std::unordered_map<int32_t, VelEntry> s_velMap;
+static ULONGLONG s_pruneAt = 0;
+
+static constexpr float kServerTickMsMin  = 115.f;
+static constexpr float kServerTickMsMax  = 290.f;
+static constexpr float kMaxVelTilesPerMs = 0.1f;
+static constexpr float kMoVelSmooth      = 0.65f;
+static constexpr float kMaxInstTilesPerMs = 0.08f;
+
+static void UpdateVelocity(int32_t id, float ex, float ey, ULONGLONG now, void* entity)
+{
+    float moVx = 0.f, moVy = 0.f;
+    bool  haveMo = false;
+    const uint32_t velOff = RuntimeOffsets::MoVelocity;
+    if (velOff != 0 && AddrOk(entity)) {
+        __try {
+            uint8_t* ent = reinterpret_cast<uint8_t*>(entity);
+            float rvx = *reinterpret_cast<float*>(ent + velOff);
+            float rvy = *reinterpret_cast<float*>(ent + velOff + 4);
+            // Only use MoVelocity when it reports actual movement — the field reads
+            // 0.0 on enemies when the offset is wrong or the entity is stationary,
+            // which would otherwise drive chord-estimated velocity toward 0 via blending.
+            if (std::isfinite(rvx) && std::isfinite(rvy) &&
+                fabsf(rvx) < kMaxVelTilesPerMs && fabsf(rvy) < kMaxVelTilesPerMs &&
+                (fabsf(rvx) > 1e-5f || fabsf(rvy) > 1e-5f)) {
+                moVx = rvx; moVy = rvy; haveMo = true;
+            }
+        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    }
+
+    auto it = s_velMap.find(id);
+    if (it == s_velMap.end()) {
+        s_velMap[id] = { ex, ey, now, haveMo ? moVx : 0.f, haveMo ? moVy : 0.f };
+        return;
+    }
+
+    VelEntry& e = it->second;
+    if (haveMo) {
+        e.vx = e.vx * (1.f - kMoVelSmooth) + moVx * kMoVelSmooth;
+        e.vy = e.vy * (1.f - kMoVelSmooth) + moVy * kMoVelSmooth;
+        e.x = ex; e.y = ey; e.t = now;
+        return;
+    }
+
+    const float dt  = static_cast<float>(now > e.t ? (now - e.t) : 1ULL);
+    const float dtC = (dt < 1.f) ? 1.f : (dt > 500.f ? 500.f : dt);
+    const float dx  = ex - e.x, dy = ey - e.y;
+    float ivx = dx / dtC, ivy = dy / dtC;
+    const float mag = sqrtf(ivx * ivx + ivy * ivy);
+    if (mag > kMaxInstTilesPerMs && mag > 1e-8f) {
+        const float s = kMaxInstTilesPerMs / mag;
+        ivx *= s; ivy *= s;
+    }
+    const float distSq = dx * dx + dy * dy;
+    float blend = 0.4f;
+    if (dt >= kServerTickMsMin && dt <= kServerTickMsMax && distSq > 1e-10f)
+        blend = 0.9f;
+    if (e.t != 0 && distSq > 1e-14f) {
+        e.vx = e.vx * (1.f - blend) + ivx * blend;
+        e.vy = e.vy * (1.f - blend) + ivy * blend;
+    } else if (distSq > 1e-14f) {
+        e.vx = ivx; e.vy = ivy;
+    }
+    e.x = ex; e.y = ey; e.t = now;
+}
+
+// ── World scan helpers ───────────────────────────────────────────────────────
+static bool SehReadLocalKlassAndPos(void* local, float* outX, float* outY, uint64_t* outKlass)
+{
+    __try {
+        uint8_t* lp = reinterpret_cast<uint8_t*>(local);
+        *outX   = *reinterpret_cast<float*>(lp + kOffPosX);
+        *outY   = *reinterpret_cast<float*>(lp + kOffPosY);
+        *outKlass = *reinterpret_cast<uint64_t*>(lp);
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+}
+
+struct CandidateOut {
+    int32_t id, objType, hp, maxHp;
+    float   x, y;
+    bool    isInvulnerable, hasHealthBar;
+    void*   ptr;
+};
+
+// Returns true if the dict entry describes a targetable enemy.
+// Soft properties (invulnerable, hasHealthBar) are always populated so callers
+// can apply their own targeting policies.
+static bool SehReadCandidate(uint8_t* entry, void* local, uint64_t localKlass, CandidateOut& out)
+{
+    __try {
+        if (*reinterpret_cast<int32_t*>(entry) < 0)
+            return false;
+        void* entity = *reinterpret_cast<void**>(entry + 16);
+        if (!entity || entity == local)
+            return false;
+        if (*reinterpret_cast<uint64_t*>(entity) == localKlass)
+            return false;
+
+        void* objProps = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(entity) + kOffObjProps);
+        if (!AddrOk(objProps))
+            return false;
+        uint8_t* op  = reinterpret_cast<uint8_t*>(objProps);
+        uint8_t* ent = reinterpret_cast<uint8_t*>(entity);
+
+        if (!*reinterpret_cast<uint8_t*>(op + kOffOpIsEnemy))
+            return false;
+
+        // noHealthBar (walls/destructibles) — stored as metadata, not hard-rejected
+        const uint8_t noHB = *reinterpret_cast<uint8_t*>(op + kOffOpNoHealthBar);
+
+        // XML <Invincible/> — check InvincibleElement string length
+        bool isInvuln = false;
+        void* invPtr = *reinterpret_cast<void**>(op + kOffOpInvincElem);
+        if (invPtr && AddrOk(invPtr)) {
+            int32_t strLen = -1;
+            __try { strLen = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(invPtr) + 0x10); }
+            __except (EXCEPTION_EXECUTE_HANDLER) {}
+            if (strLen > 0) isInvuln = true;
+        }
+
+        const int32_t hp    = *reinterpret_cast<int32_t*>(ent + kOffHp);
+        const int32_t maxHp = *reinterpret_cast<int32_t*>(ent + kOffMaxHp);
+        if (hp <= 0 || maxHp <= 0)
+            return false;
+
+        const int32_t objType = *reinterpret_cast<int32_t*>(ent + kOffObjType);
+        if (!IsWhitelistedType(objType)) {
+            if (maxHp == 200)
+                return false;
+            if (IsIgnoredType(objType))
+                return false;
+        }
+
+        // Runtime condition check (stasis / runtime invincible)
+        uint32_t cond0 = 0, cond1 = 0;
+        const bool condOk = RuntimeOffsets::TryReadMapObjectConditions(entity, &cond0, &cond1);
+        if (condOk && (cond0 | cond1) && RuntimeOffsets::MapObjectConditionsMakeUntargetable(cond0, cond1))
+            return false;
+
+        out.id            = *reinterpret_cast<int32_t*>(entry + 8);
+        out.objType       = objType;
+        out.hp            = hp;
+        out.maxHp         = maxHp;
+        out.x             = *reinterpret_cast<float*>(ent + kOffPosX);
+        out.y             = *reinterpret_cast<float*>(ent + kOffPosY);
+        out.isInvulnerable = isInvuln;
+        out.hasHealthBar  = (noHB == 0);
+        out.ptr           = entity;
+        return true;
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+}
+
+// ── Frame state ──────────────────────────────────────────────────────────────
+static std::vector<EnemyTracker::Entry> s_snapshot;
+static std::atomic<int32_t>  s_localPlayerObjectId{ 0 };
+static ULONGLONG             s_lastTickMs = 0;
+
+} // namespace
+
+namespace EnemyTracker {
+
+void Tick()
+{
+    // Self-throttle: dedupes the aim path and EnumerateLiveEnemies callers within
+    // a frame, and bounds the world-dict walk to ~125 Hz. On a throttled call the
+    // previous snapshot (≤8 ms old) is kept rather than cleared.
+    const ULONGLONG now = GetTickCount64();
+    if (now - s_lastTickMs < 8ULL) return;
+    s_lastTickMs = now;
+
+    s_snapshot.clear();
+
+    void* local = GameState::GetLocalPtr();
+    if (!local) return;
+
+    float px = 0.f, py = 0.f;
+    uint64_t localKlass = 0;
+    if (!SehReadLocalKlassAndPos(local, &px, &py, &localKlass) || localKlass == 0)
+        return;
+
+    void* wm = GameState::GetWorldMgr();
+    if (!AddrOk(wm)) return;
+
+    void* allDict = nullptr;
+    __try { allDict = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(wm) + kOffWmDict); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return; }
+    if (!AddrOk(allDict)) return;
+
+    void*   entries = nullptr;
+    int32_t count   = 0;
+    __try {
+        entries = *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(allDict) + kOffDictEnt);
+        count   = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(allDict) + kOffDictCnt);
+    } __except (EXCEPTION_EXECUTE_HANDLER) { return; }
+    if (!AddrOk(entries) || count <= 0) return;
+
+    int32_t maxLen = 0;
+    __try { maxLen = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(entries) + kOffArrMax); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return; }
+
+    const int32_t limit = (count < maxLen ? count : maxLen) < 4096
+                        ? (count < maxLen ? count : maxLen) : 4096;
+
+    uint8_t* base = reinterpret_cast<uint8_t*>(entries) + kOffArrData;
+
+    s_snapshot.reserve(static_cast<size_t>(limit / 4));
+
+    for (int32_t i = 0; i < limit; ++i) {
+        uint8_t* entry = base + i * kEntryStride;
+
+        // Opportunistically capture local player's dict key.
+        // The entry at offset +8 is the dict key (object ID); +16 is the entity pointer.
+        __try {
+            if (*reinterpret_cast<int32_t*>(entry) >= 0) {
+                void* ent = *reinterpret_cast<void**>(entry + 16);
+                if (ent == local)
+                    s_localPlayerObjectId.store(*reinterpret_cast<int32_t*>(entry + 8),
+                                                std::memory_order_relaxed);
+            }
+        } __except (EXCEPTION_EXECUTE_HANDLER) {}
+
+        CandidateOut cand{};
+        if (!SehReadCandidate(entry, local, localKlass, cand))
+            continue;
+
+        UpdateVelocity(cand.id, cand.x, cand.y, now, cand.ptr);
+
+        Entry e{};
+        e.id             = cand.id;
+        e.objType        = cand.objType;
+        e.x              = cand.x;
+        e.y              = cand.y;
+        e.hp             = cand.hp;
+        e.maxHp          = cand.maxHp;
+        e.isInvulnerable = cand.isInvulnerable;
+        e.hasHealthBar   = cand.hasHealthBar;
+        e.ptr            = cand.ptr;
+
+        // Populate velocity from the just-updated map
+        auto it = s_velMap.find(cand.id);
+        if (it != s_velMap.end()) {
+            e.vx = it->second.vx;
+            e.vy = it->second.vy;
+        }
+        s_snapshot.push_back(e);
+    }
+
+    // Prune stale velocity entries every 5 seconds
+    if (now >= s_pruneAt) {
+        s_pruneAt = now + 5000ULL;
+        for (auto it2 = s_velMap.begin(); it2 != s_velMap.end();) {
+            if (now - it2->second.t > 8000ULL) it2 = s_velMap.erase(it2);
+            else ++it2;
+        }
+    }
+}
+
+const std::vector<Entry>& GetSnapshot() { return s_snapshot; }
+
+void Enumerate(Callback cb, void* user)
+{
+    if (!cb) return;
+    for (const Entry& e : s_snapshot) cb(e, user);
+}
+
+int32_t GetLocalPlayerObjectId()
+{
+    return s_localPlayerObjectId.load(std::memory_order_relaxed);
+}
+
+} // namespace EnemyTracker

--- a/internal/src/features/combat/enemytracker/EnemyTracker.h
+++ b/internal/src/features/combat/enemytracker/EnemyTracker.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+// Shared, render-thread-only enemy snapshot. Call Tick() (self-throttled to
+// ~125 Hz) then consume via GetSnapshot / Enumerate. Velocity fields (vx, vy)
+// are tiles/ms, blended from MoVelocity + chord estimation.
+namespace EnemyTracker {
+
+struct Entry {
+    int32_t id;
+    int32_t objType;
+    float   x, y;
+    int32_t hp, maxHp;
+    float   vx, vy;          // tiles/ms; 0 until first velocity sample
+    bool    isInvulnerable;  // XML <Invincible/> flag
+    bool    hasHealthBar;    // false for walls/destructibles (noHealthBar)
+    void*   ptr;             // raw entity pointer (for direct field reads)
+};
+
+// Rebuilds the snapshot from the world dictionary. Self-throttled, so any
+// consumer may call it before reading and redundant calls within a frame are
+// cheap no-ops.
+void Tick();
+
+// All entries from the last Tick (no filtering).
+const std::vector<Entry>& GetSnapshot();
+
+using Callback = void(*)(const Entry&, void* user);
+void Enumerate(Callback cb, void* user);
+
+// Object ID of the local player's world-dict entry, updated each Tick.
+// More reliable than ProjectileTracking::GetLocalPlayerObjectId() which
+// depends on WorldTAB having fired at least once.
+int32_t GetLocalPlayerObjectId();
+
+} // namespace EnemyTracker

--- a/internal/src/features/control/FeatureState.cpp
+++ b/internal/src/features/control/FeatureState.cpp
@@ -37,7 +37,7 @@ namespace FeatureState {
 bool    GetAutoAimEnabled()           { return s_featAutoAimEnabled.load(std::memory_order_relaxed) != 0; }
 int     GetAutoAimMode()              { return s_featAutoAimMode.load(std::memory_order_relaxed); }
 void    SetAutoAimEnabled(bool v)     { s_featAutoAimEnabled.store(v ? 1 : 0, std::memory_order_relaxed); }
-void    SetAutoAimMode(int mode)      { s_featAutoAimMode.store(ClampInt(mode, 0, 2), std::memory_order_relaxed); }
+void    SetAutoAimMode(int mode)      { s_featAutoAimMode.store(ClampInt(mode, 0, 3), std::memory_order_relaxed); }
 
 int     GetAutoDodgeMode()            { return s_featDodgeMode.load(std::memory_order_relaxed); }
 void    SetAutoDodgeMode(int mode)    { s_featDodgeMode.store(ClampInt(mode, 0, static_cast<int>(TestTAB::DodgeMode::ZDodge)), std::memory_order_relaxed); }

--- a/internal/src/features/runtime/FeatureRuntime.cpp
+++ b/internal/src/features/runtime/FeatureRuntime.cpp
@@ -43,6 +43,7 @@ namespace {
             AutoAim::AimMode resolved = AutoAim::AimMode::ClosestToPlayer;
             if (aimMode == 1)      resolved = AutoAim::AimMode::HighestHP;
             else if (aimMode == 2) resolved = AutoAim::AimMode::ClosestToMouse;
+            else if (aimMode == 3) resolved = AutoAim::AimMode::Locked;
             AutoAim::SetAimMode(resolved);
         }
     }


### PR DESCRIPTION
The autoaim feature was a single 1,614-line `AutoAim.cpp` mixing enemy scanning, velocity tracking, target selection, lead prediction, weapon calibration, and IL2CPP hooks. This PR decomposes it into focused, single-responsibility modules, promotes enemy tracking to a reusable shared API, adds new targeting capabilities, and fixes a series of accuracy bugs uncovered during testing.

**Net result:** `AutoAim.cpp` shrinks from 1,614 → 239 lines (a thin coordinator), with logic distributed across 6 new modules, each under 350 lines.

## Architecture

The monolith was split into:

| Module | Responsibility |
|--------|---------------|
| `enemytracker/EnemyTracker.{h,cpp}` | **Shared** world-dict scan, snapshot cache, velocity estimation. Reusable by any feature (autoability, autododge, etc.) |
| `autoaim/AimMath.{h,cpp}` | Pure math: quadratic intercept, integrated projectile distance |
| `autoaim/WeaponProfile.{h,cpp}` | Per-shot weapon calibration (speed/lifetime/range from `projProps`) |
| `autoaim/TargetSelector.{h,cpp}` | 5-tier priority selection, 4 aim modes, phase-skip filtering, lead prediction |
| `autoaim/AimHooks.{h,cpp}` | The 3 MinHook detours (ComputeShootAngle, ShootWithAngle, SendShotPacket) |
| `autoaim/AutoAim.{h,cpp}` | Thin coordinator wiring the modules together; preserves the public API |

`EnemyTracker` is now the authoritative enemy data source — `EnemyTracker::Tick()` is self-throttled (~125 Hz), so auto-aim target selection and auto-dodge's `EnumerateLiveEnemies` both pull from one fresh snapshot instead of each walking the world dictionary independently.

## Bugs Fixed

- **Enemy velocities always read 0** — `MoVelocity` resolves to a valid offset but reads `0.0` on enemy entities; that zero was blended in at 65% weight each tick, collapsing chord-estimated velocity. Now `MoVelocity` is only trusted when non-zero, letting chord estimation drive moving-enemy lead.
- **Slow weapons never calibrated** — the speed-validation guard `rawSpeed <= 100` rejected melee weapons, which legitimately store speed `== 100` (0.01 tiles/ms). Lowered to `<= 0` so only genuine garbage is rejected. (Diagnosed via a temporary field-scanner that revealed the runtime-resolved offsets.)
- **Range zeroed for some classes** — the `0x6B8` range multiplier reads near-zero for many character classes, zeroing out a correctly-computed range. Now only applied when it looks like a real buff (`0.5×–10×`).
- **Locked mode silently overridden** — `FeatureState::SetAutoAimMode` clamped to `0..2`, truncating Locked (mode 3) and letting `FeatureRuntime` re-apply ClosestToMouse. Clamp widened to `0..3`.
- **Auto-dodge could get stale/empty enemy data** — `EnumerateLiveEnemies` read a snapshot that only refreshed when autoaim was enabled. The self-throttled `EnemyTracker::Tick()` now refreshes on demand for any consumer.
- **Local-player object-ID resolution** — the shot-owner check depended on `WorldTAB` having fired; added a reliable fallback that captures the local player's dict key directly during the `EnemyTracker` scan.

## Preserved

All original behavior is retained: the 5-tier priority system (quest/boss → normal → fallback → invulnerable), all aim modes, mouse-bounding, range-lead bias, weapon-specific tweaks (Cult Staff reverse, Colossus offset), stealth gating, and the projectile-noclip feature.

## Cleanup

- Removed all hardcoded debug logging (the old `C:\Users\...\autoaim_debug.log` path) and a temporary diagnostic overlay used during development.
- Removed verified dead code: unused `SuspendForMs`/`IsSuspended`, `EnumerateEnemyVelocities`, `TryGetEnemyAimLeadSample`, the velocity-overlay toggle, and duplicate object-type lists.

## Known Remaining Issue
- **Targeting non-enemies** — Some entities are being read as enemies, but are actually static fixtures which cannot be damaged, or killed.