### PR TITLE
Fix: ZDodge damage thresholds, projectile tracking, and aimbot targeting

### DIFF
--- a/internal/src/core/runtime/RuntimeOffsets.cpp
+++ b/internal/src/core/runtime/RuntimeOffsets.cpp
@@ -132,8 +132,6 @@ uint32_t PP_Magnitude       = 0x194;
 uint32_t PP_Frequency       = 0x198;
 uint32_t PP_Amplitude       = 0x19C;
 uint32_t PP_HasCustomAmplitude = 0x1A0;
-uint32_t PP_MinDamage       = 0x1A4;
-uint32_t PP_MaxDamage       = 0x1A8;
 uint32_t PP_CollMult              = 0xC0;
 uint32_t PP_TurnRate              = 0xD4;
 uint32_t PP_TurnRateDelay         = 0xD8;
@@ -351,8 +349,6 @@ static Entry s_entries[] = {
     { "ProjectileProperties", { "Frequency",  "frequency" },         2, 0,     &PP_Frequency,       false },
     { "ProjectileProperties", { "Amplitude",  "amplitude" },         2, 0,     &PP_Amplitude,       false },
     { "ProjectileProperties", { "HasCustomAmplitude","CustomAmplitude","customAmplitude" }, 3, 0, &PP_HasCustomAmplitude, false },
-    { "ProjectileProperties", { "MinDamage",  "minDamage" },         2, 0,     &PP_MinDamage,       false },
-    { "ProjectileProperties", { "MaxDamage",  "maxDamage" },         2, 0,     &PP_MaxDamage,       false },
     { "ProjectileProperties", { "CollisionMult","collisionMult",
                                  "ConditionEffectAmount" },          3, 0,     &PP_CollMult,        false },
     { "ProjectileProperties", { "ProjectileTurnRate", "TurnRate","turnRate"},     3, 0, &PP_TurnRate,        false },

--- a/internal/src/core/runtime/RuntimeOffsets.h
+++ b/internal/src/core/runtime/RuntimeOffsets.h
@@ -256,8 +256,6 @@ namespace RuntimeOffsets {
     extern uint32_t PP_Frequency;       // "Frequency"         fallback 0x198
     extern uint32_t PP_Amplitude;       // "Amplitude"         fallback 0x19C
     extern uint32_t PP_HasCustomAmplitude; // "HasCustomAmplitude" fallback 0x1A0 — if true, wavy uses Amplitude/Frequency fields instead of hardcoded π/64
-    extern uint32_t PP_MinDamage;       // "MinDamage"         fallback 0x1A4
-    extern uint32_t PP_MaxDamage;       // "MaxDamage"         fallback 0x1A8
     extern uint32_t PP_CollMult;           // "CollisionMult"              fallback 0xC0
     extern uint32_t PP_TurnRate;           // "ProjectileTurnRate"         fallback 0xD4
     extern uint32_t PP_TurnRateDelay;      // "ProjectileTurnRateDelay"    fallback 0xD8 — seconds; normalize ×1000

--- a/internal/src/features/combat/enemytracker/EnemyTracker.cpp
+++ b/internal/src/features/combat/enemytracker/EnemyTracker.cpp
@@ -103,26 +103,31 @@ static void UpdateVelocity(int32_t id, float ex, float ey, ULONGLONG now, void* 
         return;
     }
 
-    const float dt  = static_cast<float>(now > e.t ? (now - e.t) : 1ULL);
-    const float dtC = (dt < 1.f) ? 1.f : (dt > 500.f ? 500.f : dt);
-    const float dx  = ex - e.x, dy = ey - e.y;
-    float ivx = dx / dtC, ivy = dy / dtC;
-    const float mag = sqrtf(ivx * ivx + ivy * ivy);
-    if (mag > kMaxInstTilesPerMs && mag > 1e-8f) {
-        const float s = kMaxInstTilesPerMs / mag;
-        ivx *= s; ivy *= s;
-    }
+    const float dx = ex - e.x, dy = ey - e.y;
     const float distSq = dx * dx + dy * dy;
-    float blend = 0.4f;
-    if (dt >= kServerTickMsMin && dt <= kServerTickMsMax && distSq > 1e-10f)
-        blend = 0.9f;
-    if (e.t != 0 && distSq > 1e-14f) {
-        e.vx = e.vx * (1.f - blend) + ivx * blend;
-        e.vy = e.vy * (1.f - blend) + ivy * blend;
-    } else if (distSq > 1e-14f) {
-        e.vx = ivx; e.vy = ivy;
+    e.x = ex; e.y = ey;
+    if (distSq > 1e-14f) {
+        // dt spans the true inter-position interval (server tick), not just the poll
+        // interval, because e.t is only updated when the position actually changes.
+        const float dt  = static_cast<float>(now > e.t ? (now - e.t) : 1ULL);
+        const float dtC = (dt < 1.f) ? 1.f : (dt > 500.f ? 500.f : dt);
+        float ivx = dx / dtC, ivy = dy / dtC;
+        const float mag = sqrtf(ivx * ivx + ivy * ivy);
+        if (mag > kMaxInstTilesPerMs && mag > 1e-8f) {
+            const float s = kMaxInstTilesPerMs / mag;
+            ivx *= s; ivy *= s;
+        }
+        float blend = 0.4f;
+        if (dt >= kServerTickMsMin && dt <= kServerTickMsMax)
+            blend = 0.9f;
+        if (e.t != 0) {
+            e.vx = e.vx * (1.f - blend) + ivx * blend;
+            e.vy = e.vy * (1.f - blend) + ivy * blend;
+        } else {
+            e.vx = ivx; e.vy = ivy;
+        }
+        e.t = now;
     }
-    e.x = ex; e.y = ey; e.t = now;
 }
 
 // ── World scan helpers ───────────────────────────────────────────────────────
@@ -170,19 +175,16 @@ static bool SehReadCandidate(uint8_t* entry, void* local, uint64_t localKlass, C
         // noHealthBar (walls/destructibles) — stored as metadata, not hard-rejected
         const uint8_t noHB = *reinterpret_cast<uint8_t*>(op + kOffOpNoHealthBar);
 
-        // XML <Invincible/> — check InvincibleElement string length
-        bool isInvuln = false;
+        // XML <Invincible/> — reject if InvincibleElement pointer exists (regardless of string)
         void* invPtr = *reinterpret_cast<void**>(op + kOffOpInvincElem);
-        if (invPtr && AddrOk(invPtr)) {
-            int32_t strLen = -1;
-            __try { strLen = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(invPtr) + 0x10); }
-            __except (EXCEPTION_EXECUTE_HANDLER) {}
-            if (strLen > 0) isInvuln = true;
-        }
+        if (invPtr && AddrOk(invPtr))
+            return false;
+
+        bool isInvuln = false;
 
         const int32_t hp    = *reinterpret_cast<int32_t*>(ent + kOffHp);
         const int32_t maxHp = *reinterpret_cast<int32_t*>(ent + kOffMaxHp);
-        if (hp <= 0 || maxHp <= 0)
+        if (hp <= 0 || maxHp <= 0 || hp > maxHp)
             return false;
 
         const int32_t objType = *reinterpret_cast<int32_t*>(ent + kOffObjType);
@@ -199,12 +201,17 @@ static bool SehReadCandidate(uint8_t* entry, void* local, uint64_t localKlass, C
         if (condOk && (cond0 | cond1) && RuntimeOffsets::MapObjectConditionsMakeUntargetable(cond0, cond1))
             return false;
 
+        const float ex2 = *reinterpret_cast<float*>(ent + kOffPosX);
+        const float ey2 = *reinterpret_cast<float*>(ent + kOffPosY);
+        if (!std::isfinite(ex2) || !std::isfinite(ey2) || (ex2 == 0.f && ey2 == 0.f))
+            return false;
+
         out.id            = *reinterpret_cast<int32_t*>(entry + 8);
         out.objType       = objType;
         out.hp            = hp;
         out.maxHp         = maxHp;
-        out.x             = *reinterpret_cast<float*>(ent + kOffPosX);
-        out.y             = *reinterpret_cast<float*>(ent + kOffPosY);
+        out.x             = ex2;
+        out.y             = ey2;
         out.isInvulnerable = isInvuln;
         out.hasHealthBar  = (noHB == 0);
         out.ptr           = entity;

--- a/internal/src/features/movement/zdodge/ZDodge.cpp
+++ b/internal/src/features/movement/zdodge/ZDodge.cpp
@@ -301,7 +301,7 @@ void RenderSettings()
     if (ImGui::SliderFloat("Clearance weight##zdodge", &clearanceWeight, 0.f, 5.f)) SetClearanceWeight(clearanceWeight);
     if (ImGui::SliderFloat("Backpedal penalty##zdodge", &backpedal, 0.f, 10.f)) SetBackpedalPenalty(backpedal);
     if (ImGui::SliderFloat("Enemy no-go radius##zdodge", &enemyAvoidance, 0.f, 3.f)) SetEnemyAvoidanceRadius(enemyAvoidance);
-    if (ImGui::SliderFloat("Damage threshold pct##zdodge", &dmg, 0.f, 1.f)) SetDamageThresholdPct(dmg);
+    if (ImGui::SliderFloat("Damage threshold (0.01=1%)##zdodge", &dmg, 0.f, 1.f, "%.2f")) SetDamageThresholdPct(dmg);
     if (ImGui::Checkbox("Debug overlay##zdodge", &debug)) SetDebugOverlay(debug);
     if (ImGui::Checkbox("Candidate overlay##zdodge", &candidates)) SetCandidateOverlay(candidates);
 }

--- a/internal/src/features/movement/zdodge/ZDodgeSensors.cpp
+++ b/internal/src/features/movement/zdodge/ZDodgeSensors.cpp
@@ -168,7 +168,7 @@ SensorSnapshot Build(float playerX, float playerY, const Settings& settings)
         if (!p.valid) continue;
         if (localId != 0 && p.attackerObjId == localId) continue;
         if (localId != 0 && static_cast<int32_t>(p.ownerObjId) == localId) continue;
-        if (!p.canHitPlayer && !IsEnemyOwnedProjectile(p, enemyIds)) continue;
+        if (!p.canHitPlayer && p.attackerObjId == 0 && static_cast<int32_t>(p.ownerObjId) == 0) continue;
         if (!IsFinitePoint(p.x, p.y)) continue;
         if (DistSq(p.x, p.y, playerX, playerY) > cullSq) continue;
         if (out.threatCount >= kMaxThreats) {

--- a/internal/src/features/projectiles/ProjectileRuntimeReader.cpp
+++ b/internal/src/features/projectiles/ProjectileRuntimeReader.cpp
@@ -83,6 +83,25 @@ bool TryReadRuntimeChebyshevHalf(void* projectilePtr, float& outHalf)
     return false;
 }
 
+bool TryReadLiveDamage(void* projectilePtr, int32_t& outDamage)
+{
+    outDamage = 0;
+    if (!AddrOk(projectilePtr)) return false;
+    __try {
+        // HBEAKBIHANL.DBNNDLKNECM — per-instance damage Int32 (confirmed correct field).
+        // Read live at draw time; the game populates it shortly after spawn.
+        int32_t dmg = *reinterpret_cast<int32_t*>(
+            reinterpret_cast<uint8_t*>(projectilePtr) + RuntimeOffsets::Hbeak_InstanceDamage);
+        if (dmg > 0 && dmg < 1000000) {
+            outDamage = dmg;
+            return true;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return false;
+    }
+    return false;
+}
+
 bool ApplyProperties(WorldProjectile& dst, void* projectilePtr, void* projProps,
                      ProjectileCollisionFallback collisionFallback)
 {
@@ -99,8 +118,19 @@ bool ApplyProperties(WorldProjectile& dst, void* projectilePtr, void* projProps,
         dst.parametric = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsParametric);
         dst.frequency = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Frequency);
         dst.amplitude = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Amplitude);
-        dst.minDamage = *reinterpret_cast<int32_t*>(props + RuntimeOffsets::PP_MinDamage);
-        dst.damage = *reinterpret_cast<int32_t*>(props + RuntimeOffsets::PP_MaxDamage);
+        // Damage: HBEAKBIHANL.DBNNDLKNECM (per-instance). May still be 0 at spawn
+        // time; the authoritative value is refreshed live at draw time via
+        // TryReadLiveDamage (see ProjectileStore::FillOutFromSlot).
+        dst.damage = 0;
+        dst.minDamage = 0;
+        if (AddrOk(projectilePtr)) {
+            int32_t instDamage = *reinterpret_cast<int32_t*>(
+                reinterpret_cast<uint8_t*>(projectilePtr) + RuntimeOffsets::Hbeak_InstanceDamage);
+            if (instDamage > 0) {
+                dst.damage = instDamage;
+                dst.minDamage = instDamage;
+            }
+        }
         dst.isAccelerating = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_IsAccel);
         dst.useAccel = *reinterpret_cast<bool*>(props + RuntimeOffsets::PP_UseAccel);
         dst.acceleration = *reinterpret_cast<float*>(props + RuntimeOffsets::PP_Acceleration);

--- a/internal/src/features/projectiles/ProjectileRuntimeReader.h
+++ b/internal/src/features/projectiles/ProjectileRuntimeReader.h
@@ -14,4 +14,5 @@ namespace ProjectileRuntimeReader {
     bool TryReadRuntimeChebyshevHalf(void* projectilePtr, float& outHalf);
     bool ApplyProperties(WorldProjectile& dst, void* projectilePtr, void* projProps,
                          ProjectileCollisionFallback collisionFallback);
+    bool TryReadLiveDamage(void* projectilePtr, int32_t& outDamage);
 }

--- a/internal/src/features/projectiles/ProjectileStore.cpp
+++ b/internal/src/features/projectiles/ProjectileStore.cpp
@@ -62,6 +62,12 @@ static void FillOutFromSlot(WorldProjectile& dst, const WorldProjectile& src, UL
         float runtimeHalf = 0.f;
         ProjectileRuntimeReader::TryReadRuntimeChebyshevHalf(src.ptr, runtimeHalf);
         dst.runtimeChebyshevHalf = (runtimeHalf > 1e-5f) ? runtimeHalf : src.runtimeChebyshevHalf;
+
+        int32_t liveDamage = 0;
+        if (ProjectileRuntimeReader::TryReadLiveDamage(src.ptr, liveDamage)) {
+            dst.damage = liveDamage;
+            if (dst.minDamage <= 0 || dst.minDamage > liveDamage) dst.minDamage = liveDamage;
+        }
     }
 
     const float elapsed = static_cast<float>(now - src.spawnTick);


### PR DESCRIPTION
**Projectiles stay tracked after the enemy dies**
The threat sensor dropped any projectile whose owner was no longer a live enemy, so a dead enemy's in-flight shots instantly disappeared from the dodge logic. The filter now only discards truly ownerless projectiles, keeping dead enemies' bullets tracked until they expire.

**Damage threshold now works**
Setting the threshold to e.g. 1% previously ignored every projectile. Root cause: projectile damage was read once in the spawn hook, but the game populates the damage field (HBEAKBIHANL.DBNNDLKNECM) after construction — so it read 0, dropping every threat below the threshold. Damage is now read live from the projectile instance each frame in the draw-refresh path, matching how the in-game tracker reads it. Also removed several stale ProjectileProperties damage offsets that pointed at the wrong fields, and clarified the slider label to Damage threshold (0.01=1%).

**Aimbot lead & invincible-enemy targeting**
- Velocity estimation now measures the true server-tick interval between actual position changes instead of the faster poll interval, producing accurate projectile lead.
- Invincible enemies (<Invincible/>) are now rejected reliably via the InvincibleElement pointer rather than a fragile string-length check
- Added sanity rejections for bad entities (hp > maxHp, non-finite or (0,0) positions).