### PR TITLE
fix(offsets): update OP_IsEnemy fallback 0x6C9 → 0x6D1 (live-client verified)

### DIFF
--- a/internal/src/core/runtime/RuntimeOffsets.cpp
+++ b/internal/src/core/runtime/RuntimeOffsets.cpp
@@ -102,7 +102,9 @@ uint32_t OP_NoWallRpt     = 0x210;
 uint32_t OP_OccupySq      = 0x69A;
 uint32_t OP_FullOcc       = 0x6D1;
 uint32_t OP_EnemyOcc      = 0x6D2;
-uint32_t OP_IsEnemy       = 0x6C9;
+// isEnemy verified at 0x6D1 against the live client (upstream offset update);
+// our il2cpp-types.h dump still shows 0x6C9 — dump is stale for this region.
+uint32_t OP_IsEnemy       = 0x6D1;
 uint32_t OP_IsStatic      = 0x6D3;
 uint32_t OP_BlockProj     = 0x6D4;
 // noHealthBar bool — true when the entity type has no visible HP bar. dump 0x6C6 + 0x10 = 0x6D6.

--- a/internal/src/core/runtime/RuntimeOffsets.h
+++ b/internal/src/core/runtime/RuntimeOffsets.h
@@ -219,7 +219,7 @@ namespace RuntimeOffsets {
     extern uint32_t OP_OccupySq;    // "occupySquare"             fallback 0x69A
     extern uint32_t OP_FullOcc;     // "fullOccupy"               fallback 0x6D1
     extern uint32_t OP_EnemyOcc;    // "enemyOccupySquare"        fallback 0x6D2
-    extern uint32_t OP_IsEnemy;     // "isEnemy"                  fallback 0x6C9
+    extern uint32_t OP_IsEnemy;     // "isEnemy"                  fallback 0x6D1 (live-client verified; stale dump said 0x6C9)
     extern uint32_t OP_IsStatic;    // "isStatic"                 fallback 0x6D3
     extern uint32_t OP_BlockProj;   // "blockProjectiles"         fallback 0x6D4
     // "noHealthBar" — true when the entity type has no visible HP bar. Enemies with this set

--- a/internal/src/gui/tabs/WorldTAB.cpp
+++ b/internal/src/gui/tabs/WorldTAB.cpp
@@ -87,7 +87,8 @@ static constexpr uint32_t OFF_KJM_OBJECT_ID = 0xC0;
 // OFF_OP_* = byte offset from ObjectProperties* (klass 8 + monitor 8 + fields…).
 // Old 0x6C1+ region sits inside String* / padding — not bools; bool cluster follows il2cpp-types.h:
 // isEventChestBoss(0x698), isKey(0x699), occupySquare(0x69A),
-// then int32 type @0x69C; after displayId/displayIdWithQty pointers, isEnemy @0x6C9; fullOccupy @0x6D1,
+// then int32 type @0x69C; after displayId/displayIdWithQty pointers, isEnemy @0x6D1 (live-client
+// verified; stale dump said 0x6C9 — note this collides with the dump's fullOccupy @0x6D1),
 // enemyOccupySquare @0x6D2, isStatic @0x6D3, blockProjectiles @0x6D4; protect* @0x6DC/0x6DD; flying @0x6E4
 static const uint32_t& OFF_KJM_OBJPROPS     = RuntimeOffsets::ObjProps;
 static const uint32_t& OFF_OP_ID_STR        = RuntimeOffsets::OP_IdStr;


### PR DESCRIPTION
## Summary
- Update the `OP_IsEnemy` hardcoded fallback in `RuntimeOffsets.cpp` from `0x6C9` to `0x6D1`, with matching comment fixes in `RuntimeOffsets.h` and `WorldTAB.cpp`.
- Source: external offset-update list, independently confirmed by our own runtime resolver trace log from the last live run:
  ```
  [RuntimeOffsets] ObjectProperties::isEnemy resolved -> 0x6d1 (fallback was 0x6c9, SHIFTED)
  ```

## Context
- The generated `il2cpp-types.h` dump is stale for this region — the live client shifted the whole `ObjectProperties` bool cluster by +8 (`fullOccupy`→0x6D9, `isStatic`→0x6DB, `flying`→0x6EC, …). Runtime resolution by field name self-corrects these per frame, so the fallback only matters during the 5s give-up window.
- Skipped from the same upstream list (no usages in `internal/`): `Activate.Effect` 0x48→0x50, `IsConsumable` backing-field resolver order, `ChatManager.Update` RVA 0xB46760→0xB461E0.

## Known follow-ups (not in this PR)
- Remaining `OP_*`/`PP_*` fallbacks in the shifted region are still stale (harmless while runtime resolution works).
- Trace log shows `HBEAKBIHANL`, `GJJCEFJMNMK`, `FHOHCELBPDO` never resolve (BeeByte re-renamed) and 8 `ProjectileProperties` field names are NOT FOUND — needs a fresh IL2CPP dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)