### PR TITLE
feat(mcp): runtime-toggleable RotMG MCP diagnostics setup

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "realm-engine-diag": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${CLAUDE_PROJECT_DIR:-.}/internal/tools/re-mcp/server.mjs"],
+      "env": {}
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
   - **Autoloot** — rules for tiers, gear categories, and consumables
   - **TypeScript SDK** — write your own hacks against a typed API
 
+  ### Developer tooling
+  - **RotMG MCP server** — an [MCP](https://modelcontextprotocol.io) server (`internal/tools/re-mcp`) that lets an MCP client (e.g. Claude) **runtime-test the live DLL**: read BootGate / offset-recovery state, resolve IL2CPP classes & field offsets on demand, and watch the dodge engine's decisions. Opt-in: toggle the diagnostics bridge in the in-game **Test** tab, then approve the bundled `.mcp.json`. See [`internal/tools/re-mcp/README.md`](./internal/tools/re-mcp/README.md).
+
   ---
 
   ## 🧱 Repository layout
@@ -123,5 +126,5 @@
   <summary><strong>Keywords (for search indexing)</strong></summary>
 
   realm engine, realm engine rotmg, rotmg hacks, rotmg cheats, rotmg mods, rotmg hack client, rotmg mod client, realm of the mad god hacks, realm of the mad god mods, open source rotmg, rotmg autonexus, rotmg autododge, rotmg autoloot, rotmg pathfinding, rotmg hack builder, exalt
-   hacks, exalt mods, IL2CPP injection, RotMG, RotMG Exalt
+   hacks, exalt mods, IL2CPP injection, RotMG, RotMG Exalt, mcp, rotmg mcp, realm of the mad god mcp, realm engine mcp, model context protocol, mcp server, rotmg mcp server, claude mcp, rotmg diagnostics, il2cpp mcp, game mcp server
   </details>

--- a/internal/src/core/config/settings.h
+++ b/internal/src/core/config/settings.h
@@ -11,6 +11,13 @@ public:
  bool ImGuiInitialized = false;
  bool bShowMenu = false;
  bool bEnableUnityLogs = true;
+
+ // Developer diagnostics egress (MCP bridge). When on, DiagBridge mirrors live
+ // game/IL2CPP state to %LOCALAPPDATA%\RealmEngine\*.json so the re-mcp server
+ // (internal/tools/re-mcp) can runtime-test offset recovery and dodge behaviour.
+ // Off by default — a normal user never writes these files; a developer flips it
+ // on from the Test tab. Toggled at runtime, not compiled out.
+ bool bEnableDiagBridge = false;
 };
 
 extern Settings settings;

--- a/internal/src/core/runtime/DiagBridge.cpp
+++ b/internal/src/core/runtime/DiagBridge.cpp
@@ -7,6 +7,7 @@
 #include "Il2CppResolver.h"
 #include "DbgFileLog.h"
 #include "RePP.h"
+#include "settings.h"
 
 #include <Windows.h>
 #include <cstdio>
@@ -341,6 +342,30 @@ void WriteSnapshot(const char* dir) {
 } // namespace
 
 void Tick() {
+    // Runtime opt-in (Test tab → settings.bEnableDiagBridge). Off by default, so a
+    // normal user never touches %LOCALAPPDATA%\RealmEngine\*.json. The diag code is
+    // always compiled in — this gate just keeps it dormant until a dev enables it.
+    static bool s_prevEnabled = false;
+    if (!settings.bEnableDiagBridge) {
+        if (s_prevEnabled) {
+            // Just toggled off: remove stale files so the MCP server doesn't read a
+            // frozen snapshot as if the game were still live.
+            const char* d = DiagDir();
+            if (d) {
+                char p[MAX_PATH];
+                for (const char* fn : { "diag.json", "cmd.json", "resp.json" }) {
+                    snprintf(p, sizeof(p), "%s\\%s", d, fn);
+                    DeleteFileA(p);
+                }
+            }
+            s_lastSnapMs = 0;   // re-enabling writes a fresh snapshot immediately
+            s_lastCmdMs  = 0;
+            s_prevEnabled = false;
+        }
+        return;
+    }
+    s_prevEnabled = true;
+
     const char* dir = DiagDir();
     if (!dir) return;
     const ULONGLONG now = GetTickCount64();

--- a/internal/src/gui/tabs/TestTAB.cpp
+++ b/internal/src/gui/tabs/TestTAB.cpp
@@ -30,6 +30,7 @@ using TestTAB::DodgeMode;
 #include "FeatureState.h"
 #include "SpeedHack.h"
 #include "Noclip.h"
+#include "settings.h"
 #include "PlayerCollider.h"
 #include <imgui/imgui.h>
 
@@ -1120,6 +1121,25 @@ void TestTAB::Render()
 {
     ImGui::Spacing();
     ImGui::TextColored(ImVec4(1.f, 0.8f, 0.2f, 1.f), "TEST TOOLS");
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // ── Developer diagnostics / MCP bridge ────────────────────────────────────
+    // Runtime opt-in for the re-mcp diagnostics egress. Compiled in for everyone,
+    // dormant until flipped on here (settings.bEnableDiagBridge gates DiagBridge::Tick).
+    ImGui::TextColored(ImVec4(0.6f, 1.f, 0.7f, 1.f), "DIAGNOSTICS BRIDGE (MCP)");
+    ImGui::Checkbox("Enable diagnostics egress (MCP bridge)##diagbridge", &settings.bEnableDiagBridge);
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("%s",
+            "Developer tool. Mirrors live BootGate / offset-recovery / dodge state to\n"
+            "%LOCALAPPDATA%\\RealmEngine\\*.json so the re-mcp server (internal/tools/re-mcp)\n"
+            "can runtime-test the DLL from an MCP client. Off = nothing is written.");
+    }
+    ImGui::TextDisabled("%s", settings.bEnableDiagBridge
+        ? "Writing %LOCALAPPDATA%\\RealmEngine\\{diag,cmd,resp}.json (~1 Hz)."
+        : "Off — no files written. Enable to use the re_* MCP tools.");
+
+    ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
 

--- a/internal/tools/re-mcp/README.md
+++ b/internal/tools/re-mcp/README.md
@@ -1,8 +1,9 @@
-# Realm Engine diagnostics MCP server
+# Realm Engine diagnostics MCP server (RotMG MCP)
 
-Lets an MCP client (Claude) **runtime-test the live game DLL** — read BootGate /
-offset-recovery state, trigger IL2CPP queries on demand, and watch the dodge
-engine's decisions — without a human reading the trace log.
+An [MCP](https://modelcontextprotocol.io) server that lets an MCP client (Claude)
+**runtime-test the live game DLL** — read BootGate / offset-recovery state, trigger
+IL2CPP queries on demand, and watch the dodge engine's decisions — without a human
+reading the trace log.
 
 ```
  game.exe + version.dll  ──►  %LOCALAPPDATA%\RealmEngine\{diag,cmd,resp}.json  ──►  server.mjs (WSL)  ──►  Claude (MCP)
@@ -13,14 +14,24 @@ The DLL reads live game memory / IL2CPP metadata natively; files are just the
 egress, chosen because a WSL process reads `/mnt/c/...` directly (it cannot open a
 Windows shared-memory object).
 
+> **Two opt-ins, both off by default.** Nothing here runs unless *you* turn it on:
+> 1. **In the game** — flip *Test tab → DIAGNOSTICS BRIDGE (MCP) → Enable diagnostics
+>    egress*. A normal user never writes these files; the diag code is dormant until
+>    a developer toggles it. (Runtime toggle — no special build required.)
+> 2. **In your MCP client** — approve the bundled `.mcp.json` (below). Project MCP
+>    servers are per-user approved, so a clone never auto-runs code.
+
 ## File protocol (`%LOCALAPPDATA%\RealmEngine\`)
 
-- **`diag.json`** — rewritten ~1 Hz (atomic). BootGate state, the dependency
-  anchors (stale/healthy), the recovered projectile class, player stats, and a
-  `dodge` section (status, target lock, threat/blocker counts).
-- **`cmd.json`** — `{ "id": <ms>, "cmd": "...", "arg": "..." }`. The DLL polls
-  this ~5×/s; a new `id` triggers one execution.
+- **`diag.json`** — rewritten ~1 Hz (atomic) while the bridge is on. BootGate state,
+  the dependency anchors (stale/healthy), the recovered projectile class, player
+  stats, and a `dodge` section (status, target lock, threat/blocker counts).
+- **`cmd.json`** — `{ "id": <ms>, "cmd": "...", "arg": "..." }`. The DLL polls this
+  ~5×/s; a new `id` triggers one execution.
 - **`resp.json`** — `{ "id": <same>, "ok": bool, "result": "..." }`.
+
+Toggling the bridge **off** deletes `diag/cmd/resp.json` so a stale snapshot is never
+read as if the game were still live.
 
 ## Tools
 
@@ -31,33 +42,49 @@ Windows shared-memory object).
 | `re_resolve_class` | `Resolver::FindClassLoose(name)` — exists? | running |
 | `re_field_offset` | live `il2cpp_field_get_offset(class, field)` | running |
 | `re_dodge_state` | dodge internals (status, lock, threats) for behaviour debugging | running + dodge on |
+| `re_dump_report` | full live offset audit (Match / Shifted / FieldRenamed / …) | running |
+| `re_class_methods` | live method RVAs for a class | running |
+| `re_probe_aoe` | AoE throwable field-offset self-heal status | running + cast seen |
 
-When the game isn't running, tools return a clear "diag.json not found / no
-response" message instead of failing.
+When the game isn't running (or the bridge is off), tools return a clear
+"diag.json not found / no response" message instead of failing.
 
-## Register it (you must approve this — an agent can't self-register an MCP server)
+## Use it
 
-Add to a project `.mcp.json` (repo root) **or** run the CLI:
+1. **Enable the bridge in-game.** Build/deploy `version.dll`, launch the game, open
+   the menu (`Tab`) → **Test** tab → tick **Enable diagnostics egress (MCP bridge)**.
+   The login screen is enough — class metadata is live there.
 
-```jsonc
-// .mcp.json
-{ "mcpServers": {
-    "realm-engine-diag": {
-      "command": "node",
-      "args": ["/home/jesse/realm-engine-client/internal/tools/re-mcp/server.mjs"]
-    } } }
-```
-```bash
-claude mcp add realm-engine-diag -- node /home/jesse/realm-engine-client/internal/tools/re-mcp/server.mjs
-```
+2. **Register the MCP server.** This repo ships a project-scoped
+   [`.mcp.json`](../../../.mcp.json) at the repo root — open the project in Claude
+   Code and approve `realm-engine-diag` when prompted (project servers are per-user
+   approved; an agent can't self-register one):
 
-Then restart / reconnect the session so the server loads. Override the diag dir
-with `RE_DIAG_DIR` if your Windows user isn't `Jesse`.
+   ```jsonc
+   // .mcp.json (repo root) — already committed
+   { "mcpServers": {
+       "realm-engine-diag": {
+         "type": "stdio",
+         "command": "node",
+         "args": ["${CLAUDE_PROJECT_DIR:-.}/internal/tools/re-mcp/server.mjs"]
+       } } }
+   ```
+
+   `${CLAUDE_PROJECT_DIR:-.}` resolves to the repo root for any clone location, so no
+   absolute path is baked in. Prefer the CLI instead? From the repo root:
+
+   ```bash
+   claude mcp add realm-engine-diag -- node "$PWD/internal/tools/re-mcp/server.mjs"
+   ```
+
+3. **Override the diag dir** with `RE_DIAG_DIR` if your Windows user isn't `Jesse`
+   (the server otherwise auto-detects `%LOCALAPPDATA%` via `cmd.exe`).
+
+The server is **zero-dependency** Node (no `npm install`) and speaks MCP stdio.
 
 ## Typical runtime test
 
-1. Build + deploy `version.dll`, launch the game (login screen is enough — class
-   metadata is live there).
+1. Bridge on, game at the login screen.
 2. Claude calls `re_status` → sees BootGate state + which anchors are stale.
-3. Claude calls `re_run_recovery` → confirms it recovered the projectile class at
-   the expected offset. That's the A1 fix, verified live.
+3. Claude calls `re_run_recovery` → confirms it recovered the projectile class at the
+   expected offset. That's the fix, verified live.


### PR DESCRIPTION
## What

Makes the **re-mcp diagnostics bridge** (the RotMG MCP server under `internal/tools/re-mcp`) usable by anyone who clones the repo, and turns its egress into a **runtime opt-in** instead of always-on.

Two independent opt-ins, both off by default — nothing runs unless a developer turns it on:

1. **In the game** — *Test tab → DIAGNOSTICS BRIDGE (MCP) → Enable diagnostics egress*. A runtime toggle (no special build), so a normal user never writes `%LOCALAPPDATA%\RealmEngine\*.json`.
2. **In the MCP client** — a committed, portable `.mcp.json` that collaborators approve per-user.

## Changes

- **`settings.h`** — add `bEnableDiagBridge` (default `false`).
- **`DiagBridge.cpp`** — `Tick()` early-returns unless the toggle is on; the diag code is always compiled in but dormant. On toggle-**off** it deletes `diag/cmd/resp.json` once (so the server never reads a frozen snapshot) and resets the throttles so re-enabling writes a fresh snapshot immediately.
- **`TestTAB.cpp`** — new "DIAGNOSTICS BRIDGE (MCP)" section: checkbox, tooltip, live on/off status.
- **`.mcp.json`** (new, repo root) — project-scoped `realm-engine-diag` server using `${CLAUDE_PROJECT_DIR:-.}/internal/tools/re-mcp/server.mjs`, so there's no hardcoded path and it works from any clone. Project servers are per-user approved, so cloning never auto-runs it.
- **`internal/tools/re-mcp/README.md`** — rewritten for the runtime-toggle + `.mcp.json` flow; full 8-tool table.
- **`README.md`** — "Developer tooling → RotMG MCP server" entry + search keywords (`mcp`, `rotmg mcp`, `realm of the mad god mcp`, `model context protocol`, …).

## Notes

- Zero-dependency Node server (no `npm install`); MCP stdio.
- Default-off means no behavioral change for existing users.
- Not built via MSBuild in this PR (heavy Windows interop); the C++ gate uses existing file-scope statics and `<Windows.h>` APIs already in the TU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)