### PR TITLE
fix(client): stop false "RotMG already running" block on non-English Windows

### DIFF
--- a/client/electron/main.cjs
+++ b/client/electron/main.cjs
@@ -77,9 +77,15 @@ function getListeningPidsForPort(port) {
       const parts = line.trim().split(/\s+/);
       if (parts.length < 5 || parts[0].toUpperCase() !== 'TCP') return;
       const local = parts[1] || '';
-      const state = parts[3] || '';
+      const foreign = parts[2] || '';
       const pid = Number(parts[4]);
-      if (!Number.isFinite(pid) || state.toUpperCase() !== 'LISTENING') return;
+      // A listening TCP socket has a wildcard foreign endpoint (0.0.0.0:0 / [::]:0).
+      // Key off that instead of the State column ("LISTENING"), which Windows
+      // localizes by UI language (German "ABHÖREN", French "À L'ÉCOUTE", …) and
+      // would otherwise make this return nothing — leaving stale dev proxies
+      // un-cleaned — on non-English PCs.
+      const isListening = /:0$/.test(foreign);
+      if (!Number.isFinite(pid) || !isListening) return;
       if (portPattern.test(local)) pids.add(pid);
     });
     return Array.from(pids);

--- a/client/src/dashboard/process/exaltRoleGovernor.ts
+++ b/client/src/dashboard/process/exaltRoleGovernor.ts
@@ -39,7 +39,7 @@ export function applyRoleTrimPolicyFromDisk() {
 
 /**
  * Safety reset: Normal priority + full CPU affinity, clears parked list, stops CPU watchdog, clears dashboard preset name.
- * Optionally activates a power plan whose name matches /balanced/i (typically "Balanced").
+ * Optionally activates the Balanced power plan (matched by its well-known GUID, name as fallback).
  */
 export async function restoreAllClientTuning(options?: {
   activateBalancedPowerPlan?: boolean;
@@ -65,7 +65,14 @@ export async function restoreAllClientTuning(options?: {
 
     if (options?.activateBalancedPowerPlan && sup.ok) {
       const plans = await listPowerPlans();
+      // Prefer the well-known Balanced scheme GUID. Matching the friendly name
+      // alone fails on non-English Windows, where powercfg localizes it (German
+      // "Ausbalanciert", Spanish "Equilibrado", Japanese "バランス", …), so the
+      // safety reset would never re-apply Balanced. Name match stays as fallback.
+      const BALANCED_GUID = '381b4222-f694-41f0-9685-ff5bb260df2e';
+      const guidOnly = (g: string): string => String(g).replace(/[{}]/g, '').trim().toLowerCase();
       const bal =
+        plans.find((p) => guidOnly(p.guid) === BALANCED_GUID) ||
         plans.find((p) => /\bbalanced\b/i.test(p.name)) ||
         plans.find((p) => /^balanced$/i.test(String(p.name).trim()));
       if (bal) await activatePowerPlan(bal.guid);

--- a/client/src/dashboard/process/rotmgWindowsClientTune.ts
+++ b/client/src/dashboard/process/rotmgWindowsClientTune.ts
@@ -833,9 +833,10 @@ export async function activatePowerPlan(rawGuid: string): Promise<{ ok: boolean;
   if (!g) return { ok: false, error: 'Invalid power scheme GUID.' };
 
   const r = await execFileCmd([powerCfgExePath(), '/setactive', g]);
-  if ((r.stderr || '').toLowerCase().includes('unable') || (r.stderr || '').includes('権限')) {
-    return { ok: false, error: r.stderr.trim() || 'powercfg refused.' };
-  }
+  // Don't classify the outcome by powercfg's stderr text — its access-denied
+  // message is localized by the Windows UI language, so the old "unable"/"権限"
+  // check missed German/French/Spanish/etc. failures. Verify the active scheme
+  // actually changed, then fall back to the exit code; both are locale-independent.
   await new Promise((x) => setTimeout(x, 120));
   const verify = await getActiveSchemeGuid();
   if (verify?.toLowerCase() === g.toLowerCase()) return { ok: true };

--- a/client/src/dashboard/server/DevServer.ts
+++ b/client/src/dashboard/server/DevServer.ts
@@ -145,6 +145,39 @@ import {
 import { normalizeSlotCount, toBoolArray, extractTradeItemIncluded, parseOfferSlots } from '../../util/tradeSlots.js';
 import { WikiSpriteService } from './wikiSpriteService.js';
 
+/**
+ * Count running processes matching an image name, locale-independently.
+ *
+ * `tasklist` prints a localized "no tasks are running" notice (English "INFO:",
+ * German "INFORMATION:", Spanish "INFORMACIÓN:", Japanese "情報:", …) to stdout —
+ * and exits 0 — when nothing matches the filter. We must NOT blacklist that prose
+ * by its English "INFO:" prefix: on a non-English PC the prefix differs, the line
+ * survives, and the count is a false 1. Instead count only genuine CSV process
+ * rows, identified by their first quoted field ("RotMG Exalt.exe","1234",…); the
+ * notice is unquoted prose, so this is correct on every UI language.
+ */
+function countRunningProcessesByImageName(imageName: string): number {
+  try {
+    const output = execFileSync('tasklist', ['/FI', `IMAGENAME eq ${imageName}`, '/FO', 'CSV', '/NH'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    const normalize = (s: string): string => s.replace(/\u00A0/g, ' ').trim().toLowerCase();
+    const target = normalize(imageName);
+    return String(output || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((line) => {
+        const m = line.match(/^"([^"]*)"/);
+        return m !== null && normalize(m[1]) === target;
+      }).length;
+  } catch (err) {
+    Logger.warn('DevServer', `Failed to inspect ${imageName} processes: ${(err as Error).message}`);
+    return 0;
+  }
+}
+
 /** `taskkill /IM msedge.exe /F /T` — frees RAM from stray Edge renderer processes (Windows only). */
 function killMicrosoftEdgeProcessesBestEffort(): {
   ok: boolean;
@@ -166,7 +199,11 @@ function killMicrosoftEdgeProcessesBestEffort(): {
     const message = String((err as Error).message || '');
     const stderr = (err as { stderr?: Buffer })?.stderr ? String((err as { stderr?: Buffer }).stderr) : '';
     const combined = `${message} ${stderr}`;
-    if (/not found|no running instance|not running/i.test(combined)) {
+    // taskkill exits non-zero (with localized "not found" text) when no msedge.exe
+    // is running. Re-check the count structurally rather than matching English
+    // strings, so a non-English PC with no Edge isn't reported as a real failure
+    // (which would surface as an HTTP 400 at the dashboard endpoint).
+    if (countRunningProcessesByImageName('msedge.exe') === 0) {
       return { ok: true, ran: false };
     }
     Logger.warn('DevServer', `kill-msedge: ${combined.trim()}`);
@@ -1319,20 +1356,7 @@ export class DevServer {
   }
 
   private getRunningProcessCount(imageName: string): number {
-    try {
-      const output = execFileSync('tasklist', ['/FI', `IMAGENAME eq ${imageName}`, '/FO', 'CSV', '/NH'], {
-        encoding: 'utf8',
-        windowsHide: true,
-      });
-      const lines = String(output || '')
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean);
-      return lines.filter((line) => !line.startsWith('INFO:')).length;
-    } catch (err) {
-      Logger.warn('DevServer', `Failed to inspect ${imageName} processes: ${(err as Error).message}`);
-      return 0;
-    }
+    return countRunningProcessesByImageName(imageName);
   }
 
   private getRunningRotmgExaltProcessCount(): number {
@@ -1347,11 +1371,14 @@ export class DevServer {
       });
       return true;
     } catch (err) {
-      const message = String((err as Error).message || '');
-      if (message.toLowerCase().includes('not found') || message.toLowerCase().includes('no running instance')) {
+      // taskkill exits non-zero when the image simply isn't running. Detect that
+      // structurally — its "not found"/"no running instance" text is localized by
+      // the Windows UI language, so matching English substrings mislabels the
+      // benign no-op as a real failure on non-English PCs.
+      if (countRunningProcessesByImageName(imageName) === 0) {
         return false;
       }
-      Logger.warn('DevServer', `Failed to terminate ${imageName}: ${message}`);
+      Logger.warn('DevServer', `Failed to terminate ${imageName}: ${String((err as Error).message || '')}`);
       return false;
     }
   }


### PR DESCRIPTION
## Problem

On any PC whose **Windows UI language is not English**, launching the client fails with:

> Close the existing RotMG Exalt process and launch again. We only support 1 account at a time right now, but later multiple accounts with proxies will be supported.

…even when **no** RotMG process is running.

## Root cause

The single-client launch gate (`DevServer.getRunningProcessCount`) counts running processes by running `tasklist /FI "IMAGENAME eq RotMG Exalt.exe" /FO CSV /NH` and counting every stdout line that does **not** start with the English literal `INFO:`.

When nothing matches the filter, `tasklist` still exits `0` and prints one informational line. On English Windows that line is `INFO: No tasks are running which match the specified criteria.` → filtered out → count `0`. But that notice is **localized** by the Windows UI language — German `INFORMATION:`, Spanish `INFORMACIÓN:`, Japanese `情報:`, Russian Cyrillic, etc. None start with `INFO:`, so the line survives the filter and is miscounted as **1 running process**, blocking launch on every non-English locale.

## Fix

Replace the English-prefix blacklist with **locale-independent CSV-row counting** — count only genuine CSV rows whose first quoted field equals the image name (the localized notice is unquoted prose). Same "match localized console text" anti-pattern fixed at four other sites surfaced by an adversarially-verified sweep:

| File | Was | Now |
|------|-----|-----|
| `DevServer.ts` | `!line.startsWith('INFO:')` count; taskkill/Edge-kill classified by English `not found` | shared `countRunningProcessesByImageName` (CSV rows); structural re-checks (Edge case otherwise threw HTTP 400 on non-English PCs) |
| `main.cjs` | netstat rows matched on localized `LISTENING` column | detect listening sockets by wildcard foreign endpoint (`0.0.0.0:0` / `[::]:0`) |
| `rotmgWindowsClientTune.ts` | powercfg `/setactive` failure via English `unable` / Japanese `権限` | active-scheme re-verification + exit code |
| `exaltRoleGovernor.ts` | Balanced power plan by localized friendly name | match well-known GUID `381b4222-…-df2e` first, name as fallback |

A 6th candidate (`Hwid.ts` WMI serial encoding) was intentionally **left as-is** — its token is deterministic/stable per machine, so changing it would only churn the `clientToken` for a rare edge case with no functional gain. The `main.cjs` reg-parse was reviewed and confirmed safe (Unity PlayerPrefs are `REG_BINARY`/`REG_DWORD` with ASCII type tokens).

## Verification

- `tsc` (`npm run build`) on this branch produces the **same 135 pre-existing errors** as the base branch (all `@realmengine/sdk` resolution / implicit-any in `src/scripts/bridge/*`, an environment SDK-linking issue) — **none in the files changed here**, i.e. these edits add zero new type errors.
- `electron/main.cjs` passes `node --check`.
- Reproduce the trigger on a non-English box: `tasklist /FI "IMAGENAME eq __nope__.exe" /FO CSV /NH` prints a notice whose leading word is not `INFO:` — the line the old filter miscounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)