### PR TITLE
Improved Auto Nexus with HP checks on NewTick()

### DIFF
--- a/client/plugins/auto-nexus.ts
+++ b/client/plugins/auto-nexus.ts
@@ -356,7 +356,10 @@ export function register(ctx: PluginContext) {
 
     const deltaSec = (packet.data.tickTime as number ?? 200) / 1000;
     regenMethod29(state, pd, deltaSec);
-
+    if (shouldNexus(state)) {
+      if (packet) packet.send = false;
+      doNexus(client, state, `Server Side Hit`);
+    }
     // Autopot (HP + MP) is owned by the auto-drink plugin — see its HP threshold guard.
   }, { prepend: true });
 


### PR DESCRIPTION
This fixes AutoNexus completely not working when modifying hitbox size. This is not like MultiTool where it is predictive, that is impossible when modifying hitbox size.