### PR TITLE
docs: rewrite internal/CLAUDE.md + add CONTRIBUTING + post-patch runbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to Realm Engine
+
+Realm Engine is a three-part project:
+
+- **`client/`** — Electron MITM proxy + automation dashboard (TypeScript, `npm`)
+- **`internal/`** — C++ IL2CPP DLL injector, `version.dll` (Visual Studio 2022)
+- **`sdk/`** — `@realmengine/sdk` TypeScript SDK for user-authored plugins
+
+This document is the pre-flight for contributors. The deep architectural
+notes live next to the code they describe:
+
+- Top-level: [`README.md`](README.md), [`SETUP.md`](SETUP.md)
+- Native: [`internal/CLAUDE.md`](internal/CLAUDE.md),
+  [`internal/docs/UPDATING_AFTER_GAME_PATCH.md`](internal/docs/UPDATING_AFTER_GAME_PATCH.md)
+- MCP diagnostics bridge: [`internal/tools/re-mcp/README.md`](internal/tools/re-mcp/README.md)
+
+## Development environment
+
+You need:
+
+- **Windows 10/11 x64** — the client only supports Windows, and only x64.
+  macOS / Linux / Wine are not supported.
+- **RotMG Exalt** installed and playable — you'll need it to inject
+  against, and its game files are the source-of-truth for the IL2CPP
+  headers and XML data assets described in `SETUP.md`.
+- **Node.js 20+**, npm (or pnpm — `pnpm-lock.yaml` is present too).
+- **Visual Studio 2022** with the v145 toolset and Windows SDK 10.x
+  (only if you'll be touching `internal/`).
+
+First-time setup:
+
+1. Clone the repo.
+2. Follow [`SETUP.md`](SETUP.md) to regenerate the stripped IL2CPP headers
+   and download the game XML — these are per-Exalt-build files that are
+   not committed.
+3. `cd client && npm install`.
+4. `cd sdk && npm install && npm run build`.
+5. If you're touching native: open `internal/il2cpp-dll-injection.sln`.
+
+Build recipes:
+
+```bash
+# Client (dev)
+cd client && npm run dev
+
+# Client (production installer / portable)
+cd client && npm run dist          # both installer + portable
+cd client && npm run dist:portable # portable exe only
+
+# SDK
+cd sdk && npm run build
+
+# Native DLL (Release x64)
+cd internal && msbuild il2cpp-dll-injection.sln \
+  /p:Configuration=Release /p:Platform=x64
+# Output: internal/x64/Release/version.dll
+```
+
+## Working on packet definitions or offsets
+
+The wire protocol and the IL2CPP field offsets change every RotMG patch.
+Two things need updating in lockstep:
+
+- **Packet map** — `client/packages/protocol/src/generated/packet-map.ts`
+  is regenerated from an upstream `realmlib` fork. Run
+  `node client/scripts/sync-packet-map.mjs <path-to-realmlib/src>` to
+  refresh. Full runbook: `internal/docs/UPDATING_AFTER_GAME_PATCH.md`.
+- **IL2CPP offsets** — `internal/src/core/runtime/RuntimeOffsets.cpp`.
+  The table is self-healing (fallbacks + live IL2CPP metadata lookup),
+  so most game patches don't need a code change. When the in-game
+  **Test → OFFSET HEALTH** panel goes yellow/red, that runbook again
+  applies.
+
+## Coding style
+
+- **TypeScript** — TS 5.4, ESNext / ES2022 modules, `strict: true`.
+  Prefer explicit types on exported symbols. `.js` extensions in `import`
+  paths (bundler resolver).
+- **C++** — C++20, MS ABI. Prefer the existing helpers
+  (`Resolver::safe_call`, `RuntimeOffsets::ReadField<T>`,
+  `DBG_FILE_LOG`) over rolling new SEH / logging wrappers.
+- **Comments** — the existing code documents *why* offsets are what
+  they are (see `RuntimeOffsets.h` for the pattern). Continue that
+  when you add a new offset — the reason a value is what it is matters
+  more than the value itself, because the value will change next patch.
+
+## Scope discipline
+
+The scope of this project is a RotMG hack platform. Please do not open
+PRs that:
+
+- add game features that require compromising external accounts,
+  server infrastructure, or other players' data;
+- add functionality outside the game (system-wide keyloggers, remote
+  access, credential exfiltration to third-party services);
+- change the license without prior discussion.
+
+Everything that changes offsets / packets / hacks in the game itself is
+fair game.
+
+## Reporting bugs
+
+- **Bug / crash** — open a GitHub issue with the log output. Enable the
+  in-game Debug console (`_DEBUG` build) or check the `DbgFileLog` file
+  to grab the stack context.
+- **Feature request** — open a GitHub issue *or* drop it in
+  [Discord](https://discord.gg/uEKPPWz9k4).
+- **Security issue in the client itself** (e.g. the MITM proxy exposes
+  something it shouldn't) — please report privately via a Discord DM to
+  the maintainers before disclosing publicly.
+
+## Pull requests
+
+- Keep PRs focused — one feature or one bug per PR.
+- Include a summary of what you tested (what game context, what hack
+  configuration).
+- If you're touching `RuntimeOffsets` or the packet map, note the
+  Exalt build number you tested against.
+- PRs are welcome. Just don't claim you wrote the parts you didn't.
+
+## License
+
+Open source. See [LICENSE](LICENSE).

--- a/internal/.gitignore
+++ b/internal/.gitignore
@@ -27,3 +27,8 @@ il2cpp-d.*/
 
 # Auto-generated per-build handshake secret (build-prod.mjs) — never commit
 src/core/ipc/BuildSecrets.h
+
+# Reverse-engineering reference material — third-party notes, private packet
+# dumps, decompiled headers. Never distributed with the source.
+refs/
+

--- a/internal/CLAUDE.md
+++ b/internal/CLAUDE.md
@@ -1,106 +1,226 @@
-# CLAUDE.md
+# CLAUDE.md — realm-engine-client / internal
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in the C++ IL2CPP
+injection layer (`internal/`).
 
-## Project Overview
+## Project overview
 
-This is a C++ DLL injection framework targeting Unity IL2CPP games (specifically Realm of the Mad God Exalt). It is built as a Visual Studio solution (`il2cpp-dll-injection.sln`) and produces `version.dll` — a proxy DLL that hijacks Windows' `version.dll` for auto-loading, or can be injected directly.
+`internal/` is a Visual Studio 2022 C++ project that produces `version.dll` —
+a DLL loaded by RotMG Exalt (either as a proxy for the real Windows
+`version.dll`, or manually injected). Once loaded it hooks IL2CPP methods
+and `IDXGISwapChain::Present` to run the in-game hack overlay and
+autonomy features.
 
-The reference files in `C:\Users\trump\Desktop\Current\` (DIA4A cheat source, Flash client, bot client, dumped assembly listing, research docs) are read-only context for understanding game internals. All active development is in this `C++Scaffolding` directory.
+External reverse-engineering material — Il2CppInspectorPro dumps, notes
+from Flash/bot-client research, decompiled headers — lives under
+`internal/refs/` and is `.gitignore`d. It is read-only reference context;
+active development is entirely in `src/`.
 
-## Building
+## Build
 
-Open `il2cpp-dll-injection.sln` in Visual Studio 2022 (toolset v145). Build targets:
+Open `il2cpp-dll-injection.sln` in Visual Studio 2022 (toolset `v145`).
+The two active configurations are x64:
 
-- **x64 | Debug** — enables `_DEBUG` (spawns a console) and `_VERSION` (proxy DLL mode). Output: `x64/Debug/version.dll`
-- **x64 | Release** — same flags minus `_DEBUG`, with LTCG. Output: `x64/Release/version.dll`
-- **Win32 configs** — injector mode only (no `_VERSION`, no proxy), 32-bit builds for legacy use
+| Configuration | Defines | Output | Use for |
+|---|---|---|---|
+| `x64 \| Debug` | `_DEBUG`, `_VERSION` | `x64/Debug/version.dll` | Local dev — spawns a Win32 console for `std::cout`, `SecurityWatcherThread` is a no-op. |
+| `x64 \| Release` | `_VERSION` (+ LTCG) | `x64/Release/version.dll` | Ship builds — anti-debug active, no console. |
 
-The x64 configs are the ones in active use. MSBuild CLI equivalent:
+The `Win32` configurations exist for legacy manual-injector mode (no
+`_VERSION`, no proxy DLL export) and are not part of the active workflow.
+
+MSBuild CLI equivalent:
+
 ```
 msbuild il2cpp-dll-injection.sln /p:Configuration=Release /p:Platform=x64
 ```
 
-## Key Preprocessor Defines
+`build-and-test.bat` (repo root of `internal/`) is the fast local wrapper.
+
+## Preprocessor defines
 
 | Define | Effect |
-|--------|--------|
-| `_VERSION` | Enables proxy DLL mode: `DllMain` calls `Load()` which forwards all `version.dll` exports to the real system DLL, waits 6 seconds, then calls `Run()` |
-| `_DEBUG` | Opens a Win32 console for `std::cout` log output |
+|---|---|
+| `_VERSION` | Proxy-DLL mode. `DllMain` calls `Load()` which forwards all 17 `version.dll` exports to the real system DLL loaded from `System32`, waits 6 seconds, then runs `Run()`. |
+| `_DEBUG` | Opens a Win32 console for log output and disables `SecurityWatcherThread` (which otherwise unloads the DLL if a debugger / x64dbg / Scylla-hide is detected). |
 
-Without `_VERSION`, `DllMain` calls `Run()` directly (manual injector mode).
+Without `_VERSION`, `DllMain` calls `Run()` directly (manual-injector mode).
 
-## Architecture
+## Source layout
 
-### Startup Flow
+The project is organised by concern under `src/`:
+
+```
+src/
+├── bootstrap/           DllMain, main entry, version.dll proxy exports
+│   ├── dllmain.cpp      DLL entrypoint — dispatches to Load()/Run()
+│   ├── main.cpp/.h      Run() — init_il2cpp → AttachIl2Cpp → DetourInitilization
+│   ├── version.cpp/.h   Proxy stubs for the 17 real version.dll exports (WRAPPER_* macros)
+│
+├── core/                Cross-cutting infrastructure — no game-feature logic here
+│   ├── config/          Persistent settings (settings.h/.cpp) and keybinds (keybinds.h/.cpp)
+│   ├── il2cpp/          PCH (pch-il2cpp.h) + IL2CPP API resolver (il2cpp-init.cpp)
+│   ├── ipc/             Bridge to the Electron client (handshake, framing, JSON, tile state)
+│   ├── logging/         DBG_FILE_LOG macro + Debug console helpers
+│   ├── runtime/         BootGate, DiagBridge, GameState, LocalPlayer,
+│   │                    RuntimeOffsets, SharedMemory, Il2CppResolver
+│   └── security/        xorstr for compile-time string hiding
+│
+├── features/            Feature families — one folder per family
+│   ├── account/         Char select + credential/HWID capture surface
+│   ├── combat/          autoability, autoaim, autonexus, enemytracker, ghostHit
+│   ├── control/         Input-side control logic
+│   ├── loot/            Autoloot rules and inventory automation
+│   ├── misc/            One-offs that don't warrant their own family
+│   ├── movement/        collider, dodge, noclip, pjdodge, repp, speedhack, zdodge
+│   ├── projectiles/     ProjectileStore, ProjectileRuntimeReader, ProjectileTrajectory
+│   ├── runtime/         Feature-runtime plumbing shared by combat/movement tabs
+│   └── visuals/         Cosmetic overlays and tile visualisation
+│
+├── game/                Game-specific data — regenerated per Exalt build
+│   ├── generated/       IL2CPP headers from Il2CppInspectorPro (NOT COMMITTED — see SETUP.md)
+│   ├── math/            Game-math helpers (projectile parity, positional math)
+│   └── symbols/         BeebyteName.h — obfuscated ↔ readable class/field alias map
+│
+├── gui/                 ImGui rendering
+│   └── tabs/            One folder or pair per tab (WorldTAB, CameraTAB, PlayerTAB, CombatTab, VisualsTAB, TestTAB)
+│
+└── platform/            OS / renderer glue
+    ├── dx11/            Dx11 helpers (Dx11.cpp/.h)
+    └── hooks/           InitHooks (Detours+MinHook lifecycle) and DirectX.cpp (dPresent)
+```
+
+Include paths (x64 configs): `src` is the include root — headers are referred
+to by their subpath (e.g. `#include "core/runtime/RuntimeOffsets.h"`,
+`#include "gui/tabs/PlayerTAB.h"`). PCH is `src/core/il2cpp/pch-il2cpp.h`
+(built by `pch-il2cpp.cpp`).
+
+## Startup flow
 
 ```
 DllMain (DLL_PROCESS_ATTACH)
-  └─ [_VERSION] Load()          ← version.cpp: loads real version.dll, waits 6s
-       └─ Run()                 ← user/main.cpp: init + hook entry point
-            ├─ init_il2cpp()    ← resolves IL2CPP API from GameAssembly.dll via GetProcAddress
-            ├─ AttachIl2Cpp()   ← attaches to IL2CPP domain/thread
-            ├─ DetourInitilization() ← hooks IDXGISwapChain::Present
-            └─ UnloadWatcherThread ← waits for hUnloadEvent, then tears down cleanly
+  └─ [_VERSION] Load()                              bootstrap/version.cpp — loads real System32/version.dll, waits 6s
+       └─ Run()                                     bootstrap/main.cpp
+            ├─ (Release) SecurityWatcherThread     unloads if debugger/scylla-hide is present
+            ├─ init_il2cpp(hGameAssembly)          resolves IL2CPP API from GameAssembly.dll
+            ├─ AttachIl2Cpp()                      attaches to IL2CPP domain/thread
+            ├─ DetourInitilization()               installs IDXGISwapChain::Present detour
+            └─ UnloadWatcherThread                 waits on hUnloadEvent, then tears down cleanly
 ```
 
-### Hook Architecture
+## Hook architecture
 
-All hooks are installed/uninstalled through `handlers/hooks/InitHooks.cpp`:
+All hooks are installed / uninstalled through
+`platform/hooks/InitHooks.cpp`:
 
-- **Detours** (MS Detours library, `libraries/detours/`) — used for `IDXGISwapChain::Present` (DXGI hook). This is the render-thread entry point.
-- **MinHook** (`libraries/minhook/`) — used for IL2CPP method hooks (`ProjectileTracking`, `AutoAim`, `AoeTracking`). These install lazily from within `dPresent`/`AutoAim::Tick()` once the game has initialized.
+- **MS Detours** (`vendor/detours/`) — used for `IDXGISwapChain::Present`.
+  This is the render-thread entry point.
+- **MinHook** (`vendor/minhook/`) — used for the IL2CPP method hooks
+  (`ProjectileTracking`, `AutoAim`, `AoeTracking`). These install lazily
+  from `dPresent` / `AutoAim::Tick()` once the game has initialised.
 
-Teardown order in `DetourUninitialization()` is critical:
-1. `DirectX::Shutdown()` — stops ImGui, waits for render semaphore
-2. IL2CPP MinHook uninstalls (AoeTracking → AutoAim → ProjectileTracking)
-3. `MH_DisableHook` / `MH_Uninitialize()`
-4. Detach DXGI Present last
+Teardown order in `DetourUninitialization()` is deliberate:
 
-### Render Loop (`handlers/hooks/DirectX.cpp`)
+1. `DirectX::Shutdown()` — stops ImGui, waits for the render semaphore.
+2. IL2CPP MinHook uninstalls in reverse install order
+   (AoeTracking → AutoAim → ProjectileTracking).
+3. `MH_DisableHook` / `MH_Uninitialize()`.
+4. Detach the DXGI Present detour last.
 
-`dPresent` (the hooked `IDXGISwapChain::Present`) drives everything per frame:
-- First call: initializes ImGui (DX11 + Win32 backends), stores device/context/window, applies theme
-- Every call: runs `AutoAim::Tick()`, then tab `::Tick()` methods, then `Menu::Render()` if open
-- A `HANDLE` semaphore (`hRenderSemaphore`) serializes render calls against shutdown
+## Render loop (`platform/hooks/DirectX.cpp`)
 
-### IL2CPP Interop
+`dPresent` (the hooked `IDXGISwapChain::Present`) drives everything per
+frame:
 
-- `framework/il2cpp-init.cpp` — resolves all IL2CPP API functions from `GameAssembly.dll` at startup using `DO_API` macros expanding over `appdata/il2cpp-api-functions.h`
-- `appdata/` — generated headers (il2cpp types, function pointer tables, app-specific function stubs). These come from IL2CppInspectorPro and are specific to the current game version.
-- `handlers/Il2CppResolver.h/.cpp` — runtime helpers: `Resolver::FindClass`, `Resolver::GetProperty<T>`, `Resolver::SetProperty<T>`, `Resolver::Protection::safe_call` (SEH wrapper), `Resolver::FindObjectsByType`, field value formatting for the inspector UI
+- **First call:** initialises ImGui (DX11 + Win32 backends), stores the
+  device/context/window, applies the theme.
+- **Every call:** runs feature `::Tick(bool menuOpen)` methods, then renders
+  the menu if open.
+- A `HANDLE` semaphore (`hRenderSemaphore`) serialises render calls against
+  shutdown so we never render after teardown starts.
 
-### GUI (`handlers/gui/`)
+Menu layout (two ImGui windows plus a persistent overlay):
 
-Two-window ImGui layout:
-- `##MenuBar` — thin horizontal tab strip (1000×36, top-left)
-- `##MenuContent` — floating content panel (420×560, below bar)
-- Plus a persistent bottom-right "Unload DLL" overlay
+- `##MenuBar` — horizontal tab strip.
+- `##MenuContent` — floating content panel underneath.
+- Persistent bottom-right "Unload DLL" overlay.
 
-Tab index: 0=UnityExplorer, 1=Scanner, 2=World, 3=Camera, 4=Player, 5=Combat, 6=Movement, 7=Test, 8=Debug, 9=Visuals, 10=Settings
+Tab order (single source of truth is the `tabs[]` array in
+`DirectX.cpp::dPresent`):
 
-Tabs with per-frame work implement a `::Tick(bool menuOpen)` called from `dPresent` regardless of whether the menu is visible.
+| Index | Tab | Source |
+|---|---|---|
+| 0 | World | `gui/tabs/WorldTAB.{h,cpp}` |
+| 1 | Camera | `gui/tabs/CameraTAB.{h,cpp}` |
+| 2 | Player | `gui/tabs/PlayerTAB.{h,cpp}` |
+| 3 | Combat | `gui/tabs/CombatTab/CombatTAB.{h,cpp}` |
+| 4 | Visuals | `gui/tabs/VisualsTAB.{h,cpp}` |
+| 5 | Test | `gui/tabs/TestTAB.{h,cpp}` — diagnostics, IL2CPP explorer, offset health |
 
-### Settings (`user/settings.h`, `user/settings.cpp`)
+Tabs that need per-frame work (auto-aim, dodge, projectile tracking, …)
+implement `::Tick(bool menuOpen)` and are called from `dPresent` regardless
+of whether the menu is visible.
 
-Global `settings` instance (extern). Add new feature toggles here. The `KeyBinds::Config` struct (in `handlers/keybinds.h`) holds all keybind VK codes. Menu toggle is `VK_TAB` by default.
+Menu toggle: `VK_TAB` by default. All keybinds live in
+`core/config/keybinds.h` (`KeyBinds::Config` struct).
 
-### Projectile System (`handlers/hooks/ProjectileTracking.cpp`)
+## IL2CPP interop
 
-Implements Flash `Projectile.positionAt` parity for enemy shot prediction. See `docs/AUTODODGE_FLASH_PARITY.md` for the full behavior table. Key points:
-- Wavy, parametric, boomerang, amplitude, turning, and laser shot types are all implemented
-- `ComputePosAt(proj, tMs, x, y)` is the canonical position-at-time API
-- Speed multiplier comes from `GetFlashSpeedMultiplier()` (IL2CPP field `KDAJOMOFMJB` on `HBEAKBIHANL` instances)
-- `BeebyteName.h` maps obfuscated Beebyte class/field names to readable aliases
+- `core/il2cpp/il2cpp-init.cpp` resolves every IL2CPP API function from
+  `GameAssembly.dll` at startup using `DO_API` macros expanding over
+  `game/generated/il2cpp-api-functions.h`.
+- `game/generated/` — Il2CppInspectorPro output specific to the current
+  RotMG Exalt build. **Not committed** — regenerate with the steps in the
+  repo-level `SETUP.md`.
+- `core/runtime/Il2CppResolver.{h,cpp}` — runtime helpers:
+  `Resolver::FindClass`, `GetProperty<T>` / `SetProperty<T>`,
+  `Resolver::Protection::safe_call` (SEH wrapper),
+  `Resolver::FindObjectsByType`, field-value formatting for the inspector UI.
 
-### Proxy DLL (`framework/version.cpp`)
+## Runtime offsets — the piece that breaks on game patches
 
-When `_VERSION` is defined, all 17 `version.dll` exports are forwarded to the real system DLL loaded from `System32`. The `WRAPPER_GENFUNC` / `WRAPPER_FUNC` macros generate the stubs. `definitions/version.def` exports the symbols.
+`core/runtime/RuntimeOffsets.{h,cpp}` is a **table-driven, self-healing
+IL2CPP field-offset registry**. Read that file's top comment for the full
+contract; the summary is:
 
-## Include Paths (x64 configs)
+- Every offset variable is pre-initialised to its last known-good fallback.
+- `EnsureAll()` is called once per frame from `dPresent`. For each entry it
+  looks up the class by BeeByte-obfuscated name, then the field by name,
+  and overwrites the fallback with the live value.
+- If the class or field can't be resolved before a 5-second give-up
+  timeout, the fallback stays in place and the entry is marked stale in
+  the in-game **Test → OFFSET HEALTH** panel (yellow = STALE renamed,
+  red = SUSPECT = read garbage).
+- The BeeByte alias directory that maps obfuscated names to readable ones
+  is `game/symbols/BeebyteName.h` (`Beebyte::GetMap()`).
 
-`appdata`, `framework`, `user`, `handlers`, `libraries` — all relative to project root. The PCH is `framework/pch-il2cpp.h` (created by `framework/pch-il2cpp.cpp`).
+**When the game patches, this table is the first thing to update.** See
+`docs/UPDATING_AFTER_GAME_PATCH.md` for the workflow.
+
+## Projectile system
+
+`features/projectiles/` implements the Flash `Projectile.positionAt` model
+for enemy shot prediction. Key points:
+
+- Wavy, parametric, boomerang, amplitude, turning and laser shot types
+  are all implemented.
+- `ComputePosAt(proj, tMs, x, y)` is the canonical position-at-time API.
+- Speed multiplier comes from `GetFlashSpeedMultiplier()` (IL2CPP field
+  `KDAJOMOFMJB` on `HBEAKBIHANL` projectile instances — see
+  `RuntimeOffsets.h`).
+- Reference implementation for Flash-parity behaviour lives in the
+  Flash client source under `refs/prodmafia/` (specifically
+  `com/company/assembleegameclient/objects/Projectile.as`).
+
+## Proxy DLL (`bootstrap/version.cpp`)
+
+When `_VERSION` is defined, all 17 `version.dll` exports are forwarded to
+the real system DLL loaded from `System32`. The `WRAPPER_GENFUNC` /
+`WRAPPER_FUNC` macros generate the stubs. `defs/version.def` exports the
+symbols.
 
 ## Deployment
 
-Copy `x64/Release/version.dll` to the game's root directory (alongside `GameAssembly.dll`). The proxy intercepts the game's load of `version.dll` and runs `Load()` automatically.
+Copy `x64/Release/version.dll` to the game's root directory (alongside
+`GameAssembly.dll`). The proxy intercepts the game's load of `version.dll`
+and runs `Load()` automatically.

--- a/internal/docs/UPDATING_AFTER_GAME_PATCH.md
+++ b/internal/docs/UPDATING_AFTER_GAME_PATCH.md
@@ -1,0 +1,182 @@
+# Updating after a RotMG Exalt game patch
+
+Every RotMG Exalt patch rebuilds the game's IL2CPP assembly. The BeeByte
+obfuscation pass re-randomises class and field names, and field offsets
+can shift. This document is the runbook for getting `internal/` (and
+`client/`) back to green after a game update.
+
+There are three concerns, in escalating order of pain:
+
+1. **Regenerate the IL2CPP headers.** Mechanical, always required.
+2. **Refresh `RuntimeOffsets` fallbacks.** Only when the in-game
+   OFFSET HEALTH panel shows yellow / red rows.
+3. **Sync packet map + shapes if the wire protocol changed.** Rare —
+   usually the game keeps wire compatibility across a patch, but not
+   always. Sync when new packet IDs appear or an existing packet's fields
+   change.
+
+Do the steps in order and stop at the first successful build + smoke
+test — you probably don't need step 3.
+
+---
+
+## 1. Regenerate IL2CPP headers (always)
+
+See the repo-root `SETUP.md` for the full commands. Summary:
+
+1. Point [Il2CppInspectorPro](https://github.com/Jadis0x/Il2CppInspectorPro)
+   at the new `GameAssembly.dll` + `global-metadata.dat`.
+2. Generate the **C++ scaffold / application headers**.
+3. Overwrite `internal/src/game/generated/il2cpp-*.h` with the new files:
+   - `il2cpp-types.h`
+   - `il2cpp-functions.h`
+   - `il2cpp-types-ptr.h`
+   - `il2cpp-api-functions.h`
+   - `il2cpp-api-functions-ptr.h`
+   - `il2cpp-metadata-version.h`
+4. Rebuild `internal/` (VS 2022, `x64 | Release`).
+
+If it builds and injects, launch RotMG and check the in-game
+**Test → OFFSET HEALTH** panel. All rows green? You're done. Any yellow /
+red? Continue to step 2.
+
+---
+
+## 2. Refresh `RuntimeOffsets` fallbacks
+
+The table in `internal/src/core/runtime/RuntimeOffsets.cpp` is
+**self-healing** — as long as a class + field is resolvable from live
+IL2CPP metadata, the fallback is only used for the first frame. So the
+fallbacks only bite when BeeByte has:
+
+- **Renamed the field.** The class still exists, but the old obfuscated
+  name isn't there anymore. OFFSET HEALTH row is **yellow / STALE**.
+- **Renamed the class.** The whole class name is stale. OFFSET HEALTH
+  row is **yellow / no-class**.
+- **Shifted the offset in a way that breaks the ACTK model.** The
+  fallback resolves the wrong value and reads garbage. OFFSET HEALTH row
+  is **red / SUSPECT** — sanity checks in `RuntimeOffsets.cpp`
+  (`SanityCheckPlayerStats`, `SanityCheckProjDamage`) tripped.
+
+### Fixing a stale row
+
+For each flagged row, work out the new obfuscated name(s) and offset from
+the fresh Il2CppInspectorPro dump. The dump gives you both the class
+layout and the raw offsets — the tricky part is mapping old
+obfuscated-name → new obfuscated-name for the SAME semantic field.
+
+You have three cross-references to help:
+
+1. **`internal/src/game/symbols/BeebyteName.h`** — the persistent
+   obfuscated ↔ readable alias map maintained across builds. Search for
+   the readable name (e.g. `"speedMultiplier"`) to find both the old and
+   new obfuscated candidates.
+2. **`internal/refs/` and `Documents/Projects/OSR-RE/refs/prodmafia/`** —
+   the Flash client source is unobfuscated and is the ground truth for
+   what each field means semantically. Compare the surrounding fields'
+   types and offsets to identify the corresponding member.
+3. **The Test tab's UnityExplorer** — you can drill into a live
+   `LKHPPBEGNOM` instance in-game and read every field.  The one whose
+   value matches HP or MP is the one you want.
+
+Once you have the new name + verified offset:
+
+```cpp
+// Update the fallback initializer near the top of RuntimeOffsets.cpp:
+uint32_t HP = 0x20C;   // ← new offset if it moved
+
+// Update the Entry in s_entries[] (add the new name FIRST — old names
+// can stay as extra candidates for robustness across intermediate builds):
+{ "LKHPPBEGNOM", { "NEW_HP_NAME", "KJNHLADHEMH" }, 2, kActk, &HP, false },
+```
+
+Rebuild, smoke-test in-game, confirm OFFSET HEALTH is now green.
+
+### Critical rows — verify first
+
+If AutoNexus misbehaves after a patch, these are the fields that feed its
+damage calculation:
+
+- `HP`, `MaxHP`, `Defense` on `LKHPPBEGNOM` (player)
+- `Hbeak_InstanceDamage` on `HBEAKBIHANL` (projectile instance)
+
+Wrong values here don't crash — you'll just die to hits AutoNexus should
+have caught. Sanity-check them against the OFFSET HEALTH panel and by
+watching HP change in-game.
+
+---
+
+## 3. Sync packet map + wire shapes (only if needed)
+
+Only needed when the game's wire protocol changed. Symptoms:
+
+- MITM proxy logs unknown packet IDs.
+- Existing packet decoders throw / read garbage on a known ID.
+- `client/data/packet-merge-report.json` shows unresolved entries after
+  the sync-tool run.
+
+Both are decoded by `client/src/packets/PacketFactory` (Layer A — the
+Electron app's MITM proxy) and the typed `@re-headless/protocol` classes
+(Layer B — `muling-headless`). They share the same underlying map.
+
+### Update Layer B (the typed packet map)
+
+The map lives in
+`client/packages/protocol/src/generated/packet-map.ts`. It is
+regenerated from upstream `realmlib` (currently
+`HiveManager/HeadlessClient/realmlib/src` and
+`Nexus/headless/realmlib/src`, which are byte-identical).
+
+1. Sync from either upstream when they publish their post-patch map
+   update.
+2. Regenerate:
+   ```bash
+   node client/scripts/sync-packet-map.mjs \
+     ../../HiveManager/HeadlessClient/realmlib/src
+   ```
+3. The script preserves REC's historical names via a `PacketAlias` export
+   and heuristically seeds direction for any newly-added IDs (each new
+   direction line is marked `// NEW — verify`). Grep for `NEW — verify`
+   and audit each before shipping.
+
+### Update Layer A (the packet-shape definitions)
+
+Layer A is data-driven from `client/data/packet-definitions.json` (which
+generates `client/src/packets/packetDefinitions.generated.ts`). If a
+packet's fields changed:
+
+1. Update `client/data/packet-definitions.json` with the new field list.
+2. Regenerate the `.ts` (whatever build step you use — currently they
+   are kept in-sync manually; if a proper generator lands, document it
+   here).
+3. Confirm both files stay byte-identical to the upstream realmlib fork
+   you sync from (they should — REC and Hive agree on every byte after
+   the current sync).
+
+Verify with:
+
+```bash
+diff HiveManager/Manager/data/packet-definitions.json \
+     realm-engine-client/client/data/packet-definitions.json
+```
+
+An empty diff = you're green.
+
+---
+
+## Sanity: what has and hasn't changed after your update
+
+Run this quick manual smoke test after any of the above:
+
+- [ ] `internal/` builds with 0 errors, 0 warnings that touch feature code.
+- [ ] `version.dll` injects (game launches without crash-on-attach).
+- [ ] In-game **Test → OFFSET HEALTH** is all green.
+- [ ] AutoNexus fires on a known-lethal hit (safe repro: solo dungeon,
+      allow one hit above the threshold).
+- [ ] AutoDodge tracks a wavy shot correctly.
+- [ ] MITM proxy logs no `unknown packet id` for a normal play session
+      (arena, guild hall, one dungeon).
+- [ ] `muling-headless` connects and logs in without protocol errors.
+
+If any of these fails, the failing item is the debugging entrypoint — do
+not proceed with a release build until all six are green.

--- a/internal/refs/README.md
+++ b/internal/refs/README.md
@@ -1,0 +1,21 @@
+# internal/refs — reverse-engineering reference material
+
+This folder holds RE artifacts referenced during offset / packet work but
+that are **not part of the shipped source**:
+
+- private packet-shape dumps from third-party bot codebases
+- historical / experimental research notes
+- decompiled headers, if they carry attribution to their source tools
+
+The whole folder is `.gitignore`d — anything under `refs/` stays on the
+local workstation of whoever needs it and is never distributed.
+
+## Adding new reference material
+
+1. Drop the file(s) under `internal/refs/`.
+2. If the material contains attribution to a specific person's local
+   filesystem (`C:\Users\<name>\…`), scrub it before saving — the folder
+   is gitignored but local grep results still leak the trail across your
+   own machine.
+3. Note the origin + purpose in a comment at the top of the file (or in
+   this README's own list if useful project-wide).

--- a/internal/src/platform/hooks/DirectX.cpp
+++ b/internal/src/platform/hooks/DirectX.cpp
@@ -230,13 +230,24 @@ HRESULT __stdcall dPresent(IDXGISwapChain* __this, UINT SyncInterval, UINT Flags
 
 		// Render menu when open.
 		if (settings.bShowMenu) {
-			ImGui::SetNextWindowSize(ImVec2(1000, 36), ImGuiCond_Always);
+			// Menu layout — two stacked windows anchored to the top-left of the
+			// game surface. Sizes are fixed to keep the ImGui state deterministic
+			// across resolutions; the tab bar is 36 px tall and the content
+			// panel is 420 x 560 immediately below it.
+			constexpr float kMenuBarWidth   = 1000.0f;
+			constexpr float kMenuBarHeight  =   36.0f;
+			constexpr float kMenuContentW   =  420.0f;
+			constexpr float kMenuContentH   =  560.0f;
+
+			ImGui::SetNextWindowSize(ImVec2(kMenuBarWidth, kMenuBarHeight), ImGuiCond_Always);
 			ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
 			ImGui::Begin("##MenuBar", nullptr,
 				ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
 				ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
 				ImGuiWindowFlags_NoSavedSettings);
 
+			// Tab bar — the order here is the single source of truth for the
+			// tab index used in the switch below. Keep the two in lockstep.
 			static int s_tab = 0;
 			const char* tabs[] = { "World", "Camera", "Player", "Combat", "Visuals", "Test" };
 			for (int i = 0; i < IM_ARRAYSIZE(tabs); i++) {
@@ -245,18 +256,18 @@ HRESULT __stdcall dPresent(IDXGISwapChain* __this, UINT SyncInterval, UINT Flags
 			}
 			ImGui::End();
 
-			ImGui::SetNextWindowSize(ImVec2(420, 560), ImGuiCond_Always);
-			ImGui::SetNextWindowPos(ImVec2(0, 36), ImGuiCond_Always);
+			ImGui::SetNextWindowSize(ImVec2(kMenuContentW, kMenuContentH), ImGuiCond_Always);
+			ImGui::SetNextWindowPos(ImVec2(0, kMenuBarHeight), ImGuiCond_Always);
 			ImGui::Begin("##MenuContent", nullptr,
 				ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
 				ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings);
 			switch (s_tab) {
-				case 0: WorldTAB::Render();  break;
-				case 1: CameraTAB::Render(); break;
-				case 2: PlayerTAB::Render(); break;
-				case 3: CombatTAB::Render(); break;
+				case 0: WorldTAB::Render();   break;
+				case 1: CameraTAB::Render();  break;
+				case 2: PlayerTAB::Render();  break;
+				case 3: CombatTAB::Render();  break;
 				case 4: VisualsTAB::Render(); break;
-				case 5: TestTAB::Render();   break;
+				case 5: TestTAB::Render();    break;
 			}
 			ImGui::End();
 		}


### PR DESCRIPTION
## Summary

Docs-only bundle:

- **Full rewrite** of `internal/CLAUDE.md` to match the actual code layout.
- **New** `internal/docs/UPDATING_AFTER_GAME_PATCH.md` — the post-patch runbook.
- **New** top-level `CONTRIBUTING.md` for first-time contributors.
- **New** `internal/refs/README.md` + `internal/.gitignore` addition — the "RE reference material lives under `refs/`, gitignored" contract that the runbook + CLAUDE.md both reference.
- **Polish** in `internal/src/platform/hooks/DirectX.cpp` — named ImGui menu layout magic numbers as constants, plus a "tab-array order is the single source of truth" comment. No behavior change.

## Why

### `internal/CLAUDE.md`

The old file described a directory layout that doesn't exist:

| The doc said | The code actually has |
|---|---|
| `handlers/` | — |
| `framework/` | — |
| `appdata/` | — |
| `user/` | — |
| — | `bootstrap/`, `core/`, `features/`, `game/`, `gui/`, `platform/` |

It also documented an 11-tab GUI (real one is 6: World / Camera / Player / Combat / Visuals / Test), referenced a doc that doesn't exist (`docs/AUTODODGE_FLASH_PARITY.md`), and pointed at a previous maintainer's private local path (`C:\Users\trump\Desktop\Current\`) as "read-only context".

The rewrite tracks the real layout, adds a table for the tab order with source-file references, and points at the new post-patch runbook.

### `internal/docs/UPDATING_AFTER_GAME_PATCH.md`

There was no documented workflow for handling a RotMG patch. This is the first-attempt runbook, structured as three escalating concerns:

1. Regenerate IL2CPP headers (always needed).
2. Refresh `RuntimeOffsets` fallbacks (only when OFFSET HEALTH goes yellow / red — with the specific cross-references maintainers use: BeebyteName.h, prodmafia Flash source, the Test tab's UnityExplorer).
3. Sync packet map + wire shapes (rare — uses `sync-packet-map.mjs` from #36).

Ends with a six-item release-build smoke checklist (offset health, autonexus, autododge, unknown-packet-log, muling-headless login).

### `CONTRIBUTING.md`

Nothing existed between the README and the per-folder `CLAUDE.md`s for a first-time contributor. Covers env setup, build recipes, coding style, packet/offset workflow, scope discipline, PR expectations, security-issue reporting.

### `internal/refs/`

Documents the "RE reference material lives here, gitignored" convention referenced by the runbook and CLAUDE.md. `internal/.gitignore` gets `refs/` so the folder can hold private material (packet-shape dumps, third-party notes) without leaking any of it into the repo.

### `DirectX.cpp`

Small mechanical readability change — the four magic numbers for the ImGui menu layout (1000×36 menu bar, 420×560 content panel) are now `constexpr` constants next to their usage. Added a comment above the tab-name array pointing out that its order IS the source of truth for the tab index in the switch immediately below it, so future edits stay in lockstep.

## Note on the offset-recovery strip

This PR was written before `6a66ce2` (`remove offset recovery / self-healing system entirely`) landed. I've cross-checked the rewrite against post-strip HEAD:

- `EnsureAll()`, `OffsetState`, `GetOffsetReport`, sanity checks and the in-game OFFSET HEALTH panel all still exist — only the structural/A1/A4 recovery layer (`OffsetRecovery`, `QuestBoard`, `RecoverFromInstance`, `RecoverTileChain`) was removed.
- The "self-healing" the rewritten CLAUDE.md and runbook describe is the name-lookup layer, which is still active. Nothing in the docs promises the removed structural recovery.

Happy to iterate the runbook to reflect any post-strip workflow you already have in mind.