### PR TITLE
fix(client): restore non-English locale fixes lost in main (regression of #31)

### DIFF
--- a/client/electron/main.cjs
+++ b/client/electron/main.cjs
@@ -77,9 +77,15 @@ function getListeningPidsForPort(port) {
       const parts = line.trim().split(/\s+/);
       if (parts.length < 5 || parts[0].toUpperCase() !== 'TCP') return;
       const local = parts[1] || '';
-      const state = parts[3] || '';
+      const foreign = parts[2] || '';
       const pid = Number(parts[4]);
-      if (!Number.isFinite(pid) || state.toUpperCase() !== 'LISTENING') return;
+      // A listening TCP socket has a wildcard foreign endpoint (0.0.0.0:0 / [::]:0).
+      // Key off that instead of the State column ("LISTENING"), which Windows
+      // localizes by UI language (German "ABHÖREN", French "À L'ÉCOUTE", …) and
+      // would otherwise make this return nothing — leaving stale dev proxies
+      // un-cleaned — on non-English PCs.
+      const isListening = /:0$/.test(foreign);
+      if (!Number.isFinite(pid) || !isListening) return;
       if (portPattern.test(local)) pids.add(pid);
     });
     return Array.from(pids);

--- a/client/src/dashboard/process/exaltRoleGovernor.ts
+++ b/client/src/dashboard/process/exaltRoleGovernor.ts
@@ -39,7 +39,7 @@ export function applyRoleTrimPolicyFromDisk() {
 
 /**
  * Safety reset: Normal priority + full CPU affinity, clears parked list, stops CPU watchdog, clears dashboard preset name.
- * Optionally activates a power plan whose name matches /balanced/i (typically "Balanced").
+ * Optionally activates the Balanced power plan (matched by its well-known GUID, name as fallback).
  */
 export async function restoreAllClientTuning(options?: {
   activateBalancedPowerPlan?: boolean;
@@ -65,7 +65,14 @@ export async function restoreAllClientTuning(options?: {
 
     if (options?.activateBalancedPowerPlan && sup.ok) {
       const plans = await listPowerPlans();
+      // Prefer the well-known Balanced scheme GUID. Matching the friendly name
+      // alone fails on non-English Windows, where powercfg localizes it (German
+      // "Ausbalanciert", Spanish "Equilibrado", Japanese "バランス", …), so the
+      // safety reset would never re-apply Balanced. Name match stays as fallback.
+      const BALANCED_GUID = '381b4222-f694-41f0-9685-ff5bb260df2e';
+      const guidOnly = (g: string): string => String(g).replace(/[{}]/g, '').trim().toLowerCase();
       const bal =
+        plans.find((p) => guidOnly(p.guid) === BALANCED_GUID) ||
         plans.find((p) => /\bbalanced\b/i.test(p.name)) ||
         plans.find((p) => /^balanced$/i.test(String(p.name).trim()));
       if (bal) await activatePowerPlan(bal.guid);

--- a/client/src/dashboard/process/rotmgWindowsClientTune.ts
+++ b/client/src/dashboard/process/rotmgWindowsClientTune.ts
@@ -833,9 +833,10 @@ export async function activatePowerPlan(rawGuid: string): Promise<{ ok: boolean;
   if (!g) return { ok: false, error: 'Invalid power scheme GUID.' };
 
   const r = await execFileCmd([powerCfgExePath(), '/setactive', g]);
-  if ((r.stderr || '').toLowerCase().includes('unable') || (r.stderr || '').includes('権限')) {
-    return { ok: false, error: r.stderr.trim() || 'powercfg refused.' };
-  }
+  // Don't classify the outcome by powercfg's stderr text — its access-denied
+  // message is localized by the Windows UI language, so the old "unable"/"権限"
+  // check missed German/French/Spanish/etc. failures. Verify the active scheme
+  // actually changed, then fall back to the exit code; both are locale-independent.
   await new Promise((x) => setTimeout(x, 120));
   const verify = await getActiveSchemeGuid();
   if (verify?.toLowerCase() === g.toLowerCase()) return { ok: true };

--- a/client/src/dashboard/server/DevServer.ts
+++ b/client/src/dashboard/server/DevServer.ts
@@ -157,6 +157,39 @@ import {
 import { normalizeSlotCount, toBoolArray, extractTradeItemIncluded, parseOfferSlots } from '../../util/tradeSlots.js';
 import { WikiSpriteService } from './wikiSpriteService.js';
 
+/**
+ * Count running processes matching an image name, locale-independently.
+ *
+ * `tasklist` prints a localized "no tasks are running" notice (English "INFO:",
+ * German "INFORMATION:", Spanish "INFORMACIÓN:", Japanese "情報:", …) to stdout —
+ * and exits 0 — when nothing matches the filter. We must NOT blacklist that prose
+ * by its English "INFO:" prefix: on a non-English PC the prefix differs, the line
+ * survives, and the count is a false 1. Instead count only genuine CSV process
+ * rows, identified by their first quoted field ("RotMG Exalt.exe","1234",…); the
+ * notice is unquoted prose, so this is correct on every UI language.
+ */
+function countRunningProcessesByImageName(imageName: string): number {
+  try {
+    const output = execFileSync('tasklist', ['/FI', `IMAGENAME eq ${imageName}`, '/FO', 'CSV', '/NH'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    const normalize = (s: string): string => s.replace(/\u00A0/g, ' ').trim().toLowerCase();
+    const target = normalize(imageName);
+    return String(output || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((line) => {
+        const m = line.match(/^"([^"]*)"/);
+        return m !== null && normalize(m[1]) === target;
+      }).length;
+  } catch (err) {
+    Logger.warn('DevServer', `Failed to inspect ${imageName} processes: ${(err as Error).message}`);
+    return 0;
+  }
+}
+
 /** `taskkill /IM msedge.exe /F /T` — frees RAM from stray Edge renderer processes (Windows only). */
 function killMicrosoftEdgeProcessesBestEffort(): {
   ok: boolean;
@@ -178,7 +211,11 @@ function killMicrosoftEdgeProcessesBestEffort(): {
     const message = String((err as Error).message || '');
     const stderr = (err as { stderr?: Buffer })?.stderr ? String((err as { stderr?: Buffer }).stderr) : '';
     const combined = `${message} ${stderr}`;
-    if (/not found|no running instance|not running/i.test(combined)) {
+    // taskkill exits non-zero (with localized "not found" text) when no msedge.exe
+    // is running. Re-check the count structurally rather than matching English
+    // strings, so a non-English PC with no Edge isn't reported as a real failure
+    // (which would surface as an HTTP 400 at the dashboard endpoint).
+    if (countRunningProcessesByImageName('msedge.exe') === 0) {
       return { ok: true, ran: false };
     }
     Logger.warn('DevServer', `kill-msedge: ${combined.trim()}`);
@@ -1331,20 +1368,7 @@ export class DevServer {
   }
 
   private getRunningProcessCount(imageName: string): number {
-    try {
-      const output = execFileSync('tasklist', ['/FI', `IMAGENAME eq ${imageName}`, '/FO', 'CSV', '/NH'], {
-        encoding: 'utf8',
-        windowsHide: true,
-      });
-      const lines = String(output || '')
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean);
-      return lines.filter((line) => !line.startsWith('INFO:')).length;
-    } catch (err) {
-      Logger.warn('DevServer', `Failed to inspect ${imageName} processes: ${(err as Error).message}`);
-      return 0;
-    }
+    return countRunningProcessesByImageName(imageName);
   }
 
   private getRunningRotmgExaltProcessCount(): number {
@@ -1359,11 +1383,14 @@ export class DevServer {
       });
       return true;
     } catch (err) {
-      const message = String((err as Error).message || '');
-      if (message.toLowerCase().includes('not found') || message.toLowerCase().includes('no running instance')) {
+      // taskkill exits non-zero when the image simply isn't running. Detect that
+      // structurally — its "not found"/"no running instance" text is localized by
+      // the Windows UI language, so matching English substrings mislabels the
+      // benign no-op as a real failure on non-English PCs.
+      if (countRunningProcessesByImageName(imageName) === 0) {
         return false;
       }
-      Logger.warn('DevServer', `Failed to terminate ${imageName}: ${message}`);
+      Logger.warn('DevServer', `Failed to terminate ${imageName}: ${String((err as Error).message || '')}`);
       return false;
     }
   }


### PR DESCRIPTION
## Summary

**#31 shipped four locale-independent fixes back in June, but the four changed files are back to their pre-fix shape on main today.** This PR restores them verbatim from the original fix commit.

## What regressed

Grep on current `main` shows the pre-fix anti-patterns still live in all four sites:

| File:line | Pre-fix code that's currently in main | What breaks |
|---|---|---|
| `client/src/dashboard/server/DevServer.ts:1343` | `return lines.filter((line) => !line.startsWith('INFO:')).length;` | Non-English `tasklist` prints `INFORMATION:` / `INFORMACIÓN:` / `情報:` — the "no matches" notice survives the filter, gets counted as **1 running process**, blocks launch even when nothing is running |
| `client/electron/main.cjs:82` | `state.toUpperCase() !== 'LISTENING'` | Non-English `netstat` localizes the state column (`ABHÖREN`, `À L'ÉCOUTE`, …) — dev proxy detection returns nothing → stale dev proxies never get cleaned up |
| `client/src/dashboard/process/rotmgWindowsClientTune.ts:836` | `.includes('unable') \|\| .includes('権限')` | `powercfg /setactive` access-denied text is localized — the German/French/Spanish denial messages get silently classified as success |
| `client/src/dashboard/process/exaltRoleGovernor.ts:69` | `plans.find((p) => /\bbalanced\b/i.test(p.name))` | Windows localizes the friendly name (German "Ausbalanciert", Spanish "Equilibrado", Japanese "バランス", …) — the safety-reset never re-activates the Balanced plan on non-English boxes |

## How the regression happened

`1d1f93b` (the PR #31 fix commit) exists on the stale `fix/non-english-locale-launch-block` remote branch and its GitHub merge is recorded, but `main`'s history for these four files does not include it. For three of the four files there is no explanatory later commit at all — they're just back to the pre-fix text, so the merge sequence must have dropped them.

Only `DevServer.ts` was subsequently touched — by `4391732` ("Steam account support and multi-install detection"), which added 152 lines to that file starting from the pre-#31 blob and effectively re-wrote over the fix.

## What this PR does

Re-applies PR #31's original patch verbatim. `git apply --check` shows it applies cleanly against current `main` (the Steam-support additions were in a different region of `DevServer.ts`), so this is a **byte-for-byte restore** of the four fixes with no behavioral drift from #31.

The full per-site rationale + threat model is in #31 and in the docstrings that come back with this commit.

## Verification

Post-PR grep:

```
$ grep -n "countRunningProcessesByImageName\|INFO:" client/src/dashboard/server/DevServer.ts
163: * `tasklist` prints a localized "no tasks are running" notice (English "INFO:",
166: * by its English "INFO:" prefix: on a non-English PC the prefix differs, the line
171: function countRunningProcessesByImageName(imageName: string): number {
218:   if (countRunningProcessesByImageName('msedge.exe') === 0) {
1371:  return countRunningProcessesByImageName(imageName);
1390:  if (countRunningProcessesByImageName(imageName) === 0) {
```

The `INFO:` prefix filter is gone, the shared helper is present at all use sites.

## Related

- Fixes #30 (non-English Windows launch block, filed the same day #31 was originally merged — the reporter's client was likely built after the regression landed)
- Restores #31

## Preventing this from happening again

I'll open a follow-up PR that adds a minimal CI workflow — typecheck + build sanity + a grep-based guard for the four anti-patterns fixed here — so a future refactor that quietly re-introduces one of them fails CI instead of silently shipping. That way this fix stays fixed.