### PR TITLE
chore(deps): bump ws to ^8.21.2 (2 CVEs)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,7 @@
         "koffi": "^2.9.0",
         "node-addon-api": "^8.7.0",
         "sharp": "^0.33.5",
-        "ws": "^8.16.0"
+        "ws": "^8.21.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -7665,9 +7665,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
     "koffi": "^2.9.0",
     "node-addon-api": "^8.7.0",
     "sharp": "^0.33.5",
-    "ws": "^8.16.0"
+    "ws": "^8.21.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",


### PR DESCRIPTION
## Summary

Bumps `ws` from `^8.16.0` (installed `8.19.0`) to `^8.21.2`, fixing two advisories:

- **[GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx)** (HIGH — ws < 8.17.1) — **Uninitialized memory disclosure** via `cleanupBuffers`. A peer that sends a malformed frame can read up to ~65k bytes of adjacent Node heap memory back in the error response.
- **[GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p)** (MODERATE — ws < 8.20.1) — **Memory-exhaustion DoS** via tiny fragmented frames + data chunks.

Both are patched in `ws >= 8.20.1`; this PR lands us at 8.21.2 (latest 8.x, no breaking changes vs 8.19.0).

## Blast radius

The realm-engine client's MITM proxy is the direct consumer of `ws`. The memory-disclosure CVE is the one that matters here — an unfriendly server could return heap bytes from the client's process on a malformed frame. Even if the RotMG production server is trusted, the "MITM proxy" position means the client accepts frames whose ultimate origin is variable (any upstream Deca puts behind their edge, plus any private/community server the user configures via server-switch or ip-connect).

## Surgical diff

Only `ws` changed in the lockfile — 105-package install tree is otherwise identical:

```diff
    "node_modules/ws": {
-     "version": "8.19.0",
+     "version": "8.21.2",
```

No consumer code required changes (the ws API surface within 8.x is stable — this is a patch-level bump within 8.x from the consumer's perspective).

## Follow-up PRs planned

`npm audit --omit=dev --audit-level=high` on this workspace still reports 4 more highs after this PR merges. Each is a bigger jump and gets its own PR with a compat review:

- `electron-updater ^6.3.9` → `^9.7.0` — **HIGH** [GHSA-p2f4-r6v6-j797](https://github.com/advisories/GHSA-p2f4-r6v6-j797) (`Authorization` header leaked on cross-origin redirect). Three majors — needs to check `AppUpdater` API changes and `electron-builder` compat.
- `sharp ^0.33.5` → `^0.35.0` — **HIGH** [GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj) (inherited libvips CVEs). Minor within 0.x — needs quick smoke test of the sprite pipeline.
- `fast-xml-parser ^4.3.0` → `^5.7.0` — **MODERATE** [GHSA-gh4j-gqv2-49f6](https://github.com/advisories/GHSA-gh4j-gqv2-49f6). MAJOR — output shape may differ.
- `js-yaml <=4.1.1` — transitive. Would come along with an `electron-builder` bump.

Once all four are in, PR #41 (CI locale-guard) becomes a natural home for an `npm audit --omit=dev --audit-level=high` job that keeps the tree clean.