### PR TITLE
docs(sdk): flesh out sdk/README.md from 1 line to a real onboarding doc

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,1 +1,212 @@
-"# SDK" 
+# `@realmengine/sdk`
+
+TypeScript SDK for writing plugins on top of [Realm Engine](https://realmengine.org) — the open-source RotMG Exalt hack platform.
+
+You use this package if you're **writing your own hacks/utilities as user plugins** for the Realm Engine client. The bundled first-party plugins in [`client/plugins/`](../client/plugins/) already have access to a richer, unstable internal API; this SDK is the stable, sandbox-safe surface exposed to community `.mjs` plugins.
+
+---
+
+## Install
+
+```bash
+npm install --save-dev @realmengine/sdk
+```
+
+The SDK is a **types-and-shims** package: every method throws `Must be run inside RealmEngine client` at import time. That's deliberate — the real implementations are injected by the Realm Engine host at runtime. You use the SDK for IntelliSense + typechecking, then Realm Engine substitutes the real symbols when it loads your plugin.
+
+---
+
+## Your first plugin
+
+A user plugin is a single `.mjs` file that exports a `register(ctx)` function. Realm Engine watches its plugin folder ([%APPDATA%/RealmEngine/plugins](https://github.com/Evergreen-Techworks/realm-engine-client)) and hot-reloads any `.mjs` that lands there.
+
+```js
+// hello.mjs
+import { chat, events, RealmEngine } from '@realmengine/sdk';
+
+/** @param {import('@realmengine/sdk').UserPluginContext} ctx */
+export function register(ctx) {
+  ctx.name = 'Hello';
+  ctx.category = 'utility';
+
+  // Show a status line in the dashboard while the plugin is enabled.
+  RealmEngine.ui.status('Ready.');
+
+  // Announce every map change.
+  const unsub = events.onMapChanged((e) => {
+    if (!ctx.enabled) return;
+    chat.notify(`Entered ${e.name}`);
+  });
+
+  // Return a cleanup — Realm Engine calls it when the plugin is disabled/reloaded.
+  return () => unsub();
+}
+```
+
+Drop `hello.mjs` into the plugin folder, toggle it on in the dashboard, and any map change fires `Entered <name>` in your client chat.
+
+---
+
+## What's in the SDK
+
+Everything is exposed from the package root — no deep imports:
+
+```js
+import {
+  RealmEngine, chat, events, party, trade, loot, discord, inventory,
+  Self, Walking, Combat, Players, Enemies, Inventory, Vault, World,
+  Tiles, Objects, Projectiles, Log, Settings, Timing,
+  TreeScript, leaf, branch, when, cooldown, once, sequence, parallel,
+  Position, StatusEffect,
+  // …and a full set of typed events / entities / items
+} from '@realmengine/sdk';
+```
+
+Roughly grouped:
+
+| Concern | What you get | Common use |
+|---|---|---|
+| **Your player** | `Self.getHP()` / `getMaxHP()` / `getPosition()` / `getStats()` / `getExaltedBonuses()` | Auto-nexus thresholds, positional decisions |
+| **The world** | `World.isNexus()` / `isRealm()` / `isDungeon()` / `getName()`, `Tiles`, `Objects`, `Projectiles` | Behavior gated by realm/dungeon; tile queries; enemy shot readback |
+| **Other players** | `Players.nearby()`, `Enemies.nearby()`, `RealmEngine.players.*` | Party awareness, callout logic |
+| **Inventory / vault** | `Inventory`, `Vault`, `inventory.*`, backpack constants | Auto-swap, marketplace bots |
+| **Combat** | `Combat.aimAt(enemy)` / `aimAtPosition(x,y)` / `useAbility()` / `useAbilityAt(x,y)` / `useAbilityOn(enemy)`, `Projectiles.*` | Auto-ability, custom aim helpers |
+| **Movement** | `Walking.walkTo(x,y)` / `walkToPortal(name)` / `follow` / `flee` / `dodge` / `nexus()` / `teleportToPlayer` | Autopilot, safewalk, quick-travel |
+| **Events** | `events.onMapChanged`, `onEnemySpawned`, `onLevelUp`, `onPlayerNearby`, `onCharacterFameAtLeast`, `onConnected/onDisconnected`, `loot.onBagDropped`, `loot.onRareBagDropped`, … | Reactive triggers |
+| **Chat** | `chat.notify` / `say` / `yell` / `tell(name, msg)` / `party` / `guild` / `send(msg, ch)` / `onMessage` / `onWhisper` / `onChannelMessage(ch)` | Notifications; command bots |
+| **Party & trade** | `party.*`, `trade.*` | Party finder automation; trade guards |
+| **Loot** | `loot.getBags()` / `getNearbyBags(r)` / `pickup(bag, slot)` / `pickupId(id)` / `shouldPickup(objType)`, drop events, `isUT/isST/isStatPot` helpers | Rule-based auto-loot |
+| **Discord** | `discord.DiscordWebhook`, `discord.send(...)` | Push notifications outside the client |
+| **UI** | `RealmEngine.ui.status(label)` | Show a live status line on the dashboard |
+| **Timing** | `Timing.now()`, `sleep`, `every`, `after`, `debounce` | Time-based control flow |
+| **Logging** | `Log.info/warn/error(...)` | Structured plugin logs |
+| **Settings** | `ctx.registerSetting(...)`, `ctx.getSetting(...)` | User-editable knobs in the dashboard |
+| **Commands** | `ctx.registerCommand('name', args => …)` | `/name` slash commands in game chat |
+| **TreeScript** | `leaf / branch / when / cooldown / sequence / parallel` | Compose complex behavior trees without a state machine |
+
+Full method signatures are in the `.d.ts` files under [`src/`](./src/) — everything is type-annotated, so hover-docs in your editor are the fastest reference.
+
+---
+
+## Longer example — auto-nexus with a dashboard-driven threshold
+
+```js
+// safety-nexus.mjs
+import { chat, events, Self, Walking, Timing } from '@realmengine/sdk';
+
+/** @param {import('@realmengine/sdk').UserPluginContext} ctx */
+export function register(ctx) {
+  ctx.name = 'Safety Nexus';
+  ctx.category = 'combat';
+
+  ctx.registerSetting('threshold', {
+    label: 'Nexus at HP%',
+    type: 'range',
+    value: 45, min: 10, max: 90, step: 5,
+  });
+
+  // Poll HP every 100ms instead of hooking a hot per-tick path.
+  const stop = Timing.every(100, () => {
+    if (!ctx.enabled) return;
+
+    const hpPct = Self.getHPPercent();
+    const threshold = ctx.getSetting('threshold');
+
+    if (hpPct <= threshold) {
+      chat.notify(`Nexus @ ${hpPct.toFixed(0)}% (<= ${threshold}%)`);
+      Walking.nexus();  // exit to the nexus safely
+    }
+  });
+
+  return () => stop();
+}
+```
+
+The bundled first-party `auto-nexus` plugin does more than this — it hooks packet handlers to react in the same tick as an incoming hit rather than polling — but the pattern above is what most user plugins look like.
+
+---
+
+## TreeScript — behavior trees without ceremony
+
+TreeScript lets you compose complex, gated behavior as a tree of leaves + branches. Each `Leaf` is an `{ isValid, onLoop }` pair; each `Branch` picks whichever child is currently `isValid()`; helpers like `when(cond, leaf)`, `cooldown(ms, leaf)`, `sequence(...children)`, `parallel(...children)` are composition primitives.
+
+Minimal shape:
+
+```js
+import { RealmEngine, Walking, Enemies, Combat, TreeScript, leaf, branch, when, cooldown } from '@realmengine/sdk';
+
+const nexusLowHp = cooldown(1000, leaf({
+  name: 'NexusLowHp',
+  isValid: () => RealmEngine.self.getHPPercent() < 40,
+  onLoop: () => { Walking.nexus(); return 500; },
+}));
+
+const attackNearest = leaf({
+  name: 'AttackNearest',
+  isValid: () => Enemies.nearby(10).length > 0,
+  onLoop: () => { const [t] = Enemies.nearby(10); if (t) Combat.aimAt(t); return 100; },
+});
+
+class Autopilot extends TreeScript {
+  constructor() {
+    super();
+    this.root.add(branch({ name: 'combat', isValid: () => true, children: [nexusLowHp, attackNearest] }));
+  }
+}
+```
+
+See the JSDoc on `leaf`, `branch`, `cooldown`, `sequence`, `parallel`, `once`, `always`, `not`, `when` in [`src/treescript/helpers.ts`](./src/treescript/helpers.ts) for the exact contracts.
+
+---
+
+## Plugin context (`ctx`)
+
+Every plugin's `register(ctx)` receives a small object scoped to that plugin:
+
+| Field | What it is |
+|---|---|
+| `ctx.pluginId` (readonly) | Derived from the filename minus `.mjs` |
+| `ctx.pluginFile` (readonly) | Absolute path Realm Engine loaded from |
+| `ctx.name` | Dashboard display name (defaults to `pluginId`) |
+| `ctx.category` | Sidebar bucket: `'combat' \| 'movement' \| 'automation' \| 'visual' \| 'network' \| 'utility' \| 'admin'` |
+| `ctx.enabled` (readonly) | Dashboard toggle state — check this in your handlers |
+| `ctx.registerSetting(key, cfg, onChange?)` | Add a knob to the dashboard (number / boolean / range / select / text / button) |
+| `ctx.getSetting<T>(key)` | Read the current value |
+| `ctx.registerCommand(name, handler)` | Bind `/name args…` in the in-game chat |
+
+Teardown is a cleanup function you return from `register(ctx)`:
+
+```js
+export function register(ctx) {
+  const a = events.onEnemySpawned(...);
+  const b = Timing.every(1000, ...);
+  return () => { a(); b(); };
+}
+```
+
+Realm Engine calls it when the plugin is disabled, reloaded, or the client shuts down.
+
+---
+
+## What community plugins **cannot** do
+
+The `.mjs` plugin sandbox is deliberately narrower than the bundled first-party API:
+
+- No raw packet send/receive. The dashboard's packet logger is a bundled plugin because packet-level control is admin-only.
+- No arbitrary dashboard messages / structured broadcasts. Use `RealmEngine.ui.status(...)` and `chat.notify(...)`.
+- No direct DLL / IPC access — everything you can do goes through the SDK surface.
+
+If you're an operator building an admin-only bundled plugin instead, use the internal `PluginContext` in [`client/src/plugins/PluginContext.ts`](../client/src/plugins/PluginContext.ts) — same shape plus the escalated capabilities.
+
+---
+
+## Distribution
+
+- **Local install** — drop the `.mjs` into your Realm Engine plugin folder; it hot-reloads.
+- **HWID-bound marketplace scripts** — deliver an AES-256-GCM ciphertext keyed to `(userId, hwid)`; the client's `ScriptDecryptor` will decode and load it on the target machine. See [`client/src/util/ScriptDecryptor.ts`](../client/src/util/ScriptDecryptor.ts) for the threat model (short version: this scheme provides **HWID binding and integrity**, not client-side confidentiality).
+
+---
+
+## License
+
+Same as the parent project — see the [repo root LICENSE](../LICENSE).


### PR DESCRIPTION
## Summary

The published SDK README was literally:

```
# SDK
```

which is a blocker for anyone starting a Realm Engine plugin — the whole "sell your own hacks on top of this" story in the top-level README depends on plugin authors being able to actually write plugins.

This PR replaces it with a real onboarding doc, structured for the "give me the shape in 30 seconds, then let me copy-paste one working thing" reading path.

## Structure

- **Install** — one line + the types-and-shims contract (methods throw `Must be run inside RealmEngine client` at import; the client injects the real ones at plugin load).
- **Your first plugin** — a copy-pasteable hello-world with correct `register(ctx)` contract, cleanup return, `ctx.enabled` guard.
- **What's in the SDK** — a one-look surface table listing what's exposed and where it's useful.
- **Longer example** — a safety-nexus that polls HP + reads a dashboard-driven threshold setting. Only uses APIs actually present in `sdk/src`.
- **TreeScript sketch** — matches the real `leaf({...})` / `branch({...})` helper signatures. Points at the JSDoc in `helpers.ts` for the exact contracts (isValid / onLoop returns sleep-ms) instead of trying to fully reproduce them here.
- **Plugin context (`ctx`) reference** — full table for `registerSetting` / `registerCommand` / `enabled` / cleanup return.
- **What community plugins CANNOT do** — explicit list of the sandbox limits vs the internal bundled-plugin API, so operators know when to switch to `client/src/plugins/PluginContext.ts`.
- **Distribution** — local install and the HWID-bound marketplace path, with an honest pointer at the current threat model (matches #38's `SCRIPT_RUNTIME_NAMESPACE` rename).

## Verification of every code sample

Every claim was cross-checked against `sdk/src`. Notable corrections vs the naive first draft:

| Claim | Real API |
|---|---|
| ~~`RealmEngine.self.nexus()`~~ | `Walking.nexus()` |
| ~~`RealmEngine.inventory.useHealthPot()`~~ | not exposed to user SDK — drop |
| ~~`RealmEngine.combat.autoAim(true)`~~ | `Combat.aimAt(enemy)` / `aimAtPosition(x,y)` |
| ~~`events.onLootDropped`~~ | `loot.onBagDropped` / `onRareBagDropped` |
| ~~`events.onTick`~~ | doesn't exist — use `Timing.every(100, …)` |
| ~~`leaf('name', () => …)`~~ | `leaf({ name, isValid, onLoop })` |

The bundled first-party plugins in `client/plugins/` (auto-nexus, chat-filter, ip-connect, …) also served as ground truth for the `register(ctx)` contract.

## Not in this PR

- **API-reference generation.** The SDK is fully typed; hover-docs in the user's editor are the fastest reference, so an autogenerated typedoc site is a later PR (would live at `docs/` or on Pages).
- **The `sdk/` vs `client/packages/sdk/` fork.** These two SDK copies exist side-by-side and their sources have drifted (`RealmEngine.ts`, `combat/Combat.ts`, `walking/Walking.ts`, `index.ts` differ). Also worth a separate PR to converge them + declare which is the source of truth for the published package.