### PR TITLE
fix: make auto-dodge work on the 2026-08 Exalt build

### DIFF
--- a/client/plugins/auto-aim.ts
+++ b/client/plugins/auto-aim.ts
@@ -117,6 +117,12 @@ export function register(ctx: PluginContext) {
     if (!posTimer && tryOpenTelemetry()) startPosPoll();
     sendDllFeature('clientDefense', def);
     sendDllFeature('clientClassType', cls);
+    // Server-authoritative SPD (base + bonus) for the DLL's dodge move budget.
+    // The in-DLL SPD read broke on the 2026-08 layout shift; this is name/offset
+    // independent. Clamped to a sane range so a transient bad tick can't poison it.
+    const spd = pd.speed + pd.speedBonus;
+    if (Number.isFinite(spd) && spd >= 0 && spd <= 200)
+      sendDllFeature('clientSpeed', spd | 0);
   });
 
   function syncFilterState() {

--- a/internal/src/bootstrap/main.cpp
+++ b/internal/src/bootstrap/main.cpp
@@ -12,6 +12,7 @@
 #include "InitHooks.h"
 #include "IpcBridge.h"
 #include "DbgFileLog.h"
+#include "CrashProbe.h"
 
 HMODULE hModule;
 HANDLE hUnloadEvent;
@@ -76,6 +77,10 @@ void Run(LPVOID lpParam)
  SetConsoleTitleA("Debug Console");
 #endif
  DBG_FILE_LOG("[Run] Entered. Log path: " << DbgFileLogPath());
+
+ // Install crash logging as early as possible so any fatal fault (feature hook
+ // misfire, stale offset misread) records module+offset+backtrace to the trace log.
+ crashprobe::InstallCrashProbe();
 
 #if !defined(_DEBUG)
  if (IsDebuggerDetected() || HasAnalysisModulesLoaded()) return;

--- a/internal/src/core/il2cpp/il2cpp-appdata.h
+++ b/internal/src/core/il2cpp/il2cpp-appdata.h
@@ -8,9 +8,8 @@
       // Application-specific types
       #include "il2cpp-types.h"
 
-      // Missing typedefs not emitted by Il2CppInspector for this Unity version
-      typedef uint32_t Il2CppGCHandle;             // GC handle is a uint32 token
-      typedef void (*Il2CppAndroidUpStateFunc)(bool); // Android network state callback
+      // (Il2CppGCHandle / Il2CppAndroidUpStateFunc are now emitted by the
+      // regenerated il2cpp-types.h — manual typedefs removed to avoid redefinition.)
 
       // IL2CPP APIs
       #define DO_API(r, n, p) extern r (*n) p

--- a/internal/src/core/logging/CrashProbe.h
+++ b/internal/src/core/logging/CrashProbe.h
@@ -1,0 +1,157 @@
+#pragma once
+// CrashProbe — logs the exact faulting module+offset, registers, and a stack
+// backtrace to the DLL trace log when the process hits a fatal exception.
+//
+// A vectored exception handler (first-chance) is the primary catch: it fires
+// before any SEH frame handler or unhandled-exception filter, so it captures
+// the crash even if the game/mono owns the unhandled filter. We only act on
+// genuinely fatal codes (AV, stack overflow, etc.) and always return
+// EXCEPTION_CONTINUE_SEARCH so normal handling/termination is unchanged.
+//
+// Output lands in the same file as DBG_FILE_LOG:
+//   %LOCALAPPDATA%\RotMG Exalt DLL Trace.log
+
+#include <Windows.h>
+#include <cstdint>
+#include <cstdio>
+#include "DbgFileLog.h"
+
+namespace crashprobe {
+
+inline void DescribeAddr(void* addr, char* out, size_t outSz)
+{
+    HMODULE mod = nullptr;
+    if (GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCWSTR>(addr), &mod) && mod) {
+        wchar_t pathW[MAX_PATH] = {};
+        GetModuleFileNameW(mod, pathW, MAX_PATH);
+        const wchar_t* base = pathW;
+        for (const wchar_t* p = pathW; *p; ++p)
+            if (*p == L'\\' || *p == L'/') base = p + 1;
+        char nameA[MAX_PATH] = {};
+        WideCharToMultiByte(CP_UTF8, 0, base, -1, nameA, sizeof(nameA), nullptr, nullptr);
+        uintptr_t off = reinterpret_cast<uintptr_t>(addr) - reinterpret_cast<uintptr_t>(mod);
+        snprintf(out, outSz, "%s+0x%llx (base=%p)", nameA,
+                 static_cast<unsigned long long>(off), reinterpret_cast<void*>(mod));
+    } else {
+        snprintf(out, outSz, "%p (no module)", addr);
+    }
+}
+
+typedef USHORT(WINAPI* pRtlCaptureStackBackTrace)(ULONG, ULONG, PVOID*, PULONG);
+
+inline void LogException(EXCEPTION_POINTERS* ep, const char* tag)
+{
+    if (!ep || !ep->ExceptionRecord) {
+        DbgFileLogWrite("[CrashProbe] (null exception pointers)");
+        return;
+    }
+    EXCEPTION_RECORD* er = ep->ExceptionRecord;
+    CONTEXT* cx = ep->ContextRecord;
+    char line[1024];
+    char addrDesc[512];
+    DescribeAddr(er->ExceptionAddress, addrDesc, sizeof(addrDesc));
+
+    const char* codeName = "UNKNOWN";
+    switch (er->ExceptionCode) {
+        case EXCEPTION_ACCESS_VIOLATION:    codeName = "ACCESS_VIOLATION"; break;
+        case EXCEPTION_STACK_OVERFLOW:      codeName = "STACK_OVERFLOW"; break;
+        case EXCEPTION_ILLEGAL_INSTRUCTION: codeName = "ILLEGAL_INSTRUCTION"; break;
+        case EXCEPTION_PRIV_INSTRUCTION:    codeName = "PRIV_INSTRUCTION"; break;
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:  codeName = "INT_DIVIDE_BY_ZERO"; break;
+        case EXCEPTION_IN_PAGE_ERROR:       codeName = "IN_PAGE_ERROR"; break;
+        case 0xC0000374:                    codeName = "HEAP_CORRUPTION"; break;
+        default: break;
+    }
+    snprintf(line, sizeof(line), "[CrashProbe] %s code=0x%08lx (%s) at %s",
+             tag, er->ExceptionCode, codeName, addrDesc);
+    DbgFileLogWrite(line);
+
+    if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && er->NumberParameters >= 2) {
+        const char* op = er->ExceptionInformation[0] == 0 ? "READ"
+                       : er->ExceptionInformation[0] == 1 ? "WRITE"
+                       : er->ExceptionInformation[0] == 8 ? "EXECUTE" : "?";
+        snprintf(line, sizeof(line), "[CrashProbe]   AV %s of address %p",
+                 op, reinterpret_cast<void*>(er->ExceptionInformation[1]));
+        DbgFileLogWrite(line);
+    }
+
+#ifdef _M_X64
+    if (cx) {
+        snprintf(line, sizeof(line),
+            "[CrashProbe]   RIP=%p RSP=%p RBP=%p RAX=%p RBX=%p RCX=%p RDX=%p RSI=%p RDI=%p R8=%p R9=%p",
+            reinterpret_cast<void*>(cx->Rip), reinterpret_cast<void*>(cx->Rsp),
+            reinterpret_cast<void*>(cx->Rbp), reinterpret_cast<void*>(cx->Rax),
+            reinterpret_cast<void*>(cx->Rbx), reinterpret_cast<void*>(cx->Rcx),
+            reinterpret_cast<void*>(cx->Rdx), reinterpret_cast<void*>(cx->Rsi),
+            reinterpret_cast<void*>(cx->Rdi), reinterpret_cast<void*>(cx->R8),
+            reinterpret_cast<void*>(cx->R9));
+        DbgFileLogWrite(line);
+        char ripDesc[512];
+        DescribeAddr(reinterpret_cast<void*>(cx->Rip), ripDesc, sizeof(ripDesc));
+        snprintf(line, sizeof(line), "[CrashProbe]   RIP -> %s", ripDesc);
+        DbgFileLogWrite(line);
+    }
+#endif
+
+    static pRtlCaptureStackBackTrace capture = nullptr;
+    if (!capture) {
+        HMODULE nt = GetModuleHandleW(L"ntdll.dll");
+        if (nt) capture = reinterpret_cast<pRtlCaptureStackBackTrace>(
+                              GetProcAddress(nt, "RtlCaptureStackBackTrace"));
+    }
+    if (capture) {
+        void* frames[48] = {};
+        USHORT n = capture(0, 48, frames, nullptr);
+        for (USHORT i = 0; i < n; ++i) {
+            char fd[512];
+            DescribeAddr(frames[i], fd, sizeof(fd));
+            snprintf(line, sizeof(line), "[CrashProbe]   #%02u %s", i, fd);
+            DbgFileLogWrite(line);
+        }
+    }
+    DbgFileLogWrite("[CrashProbe] ---- end ----");
+}
+
+inline bool IsFatal(DWORD code)
+{
+    switch (code) {
+        case EXCEPTION_ACCESS_VIOLATION:
+        case EXCEPTION_STACK_OVERFLOW:
+        case EXCEPTION_ILLEGAL_INSTRUCTION:
+        case EXCEPTION_PRIV_INSTRUCTION:
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        case EXCEPTION_IN_PAGE_ERROR:
+        case 0xC0000374: // heap corruption
+            return true;
+        default:
+            return false;
+    }
+}
+
+inline LONG WINAPI VectoredHandler(EXCEPTION_POINTERS* ep)
+{
+    static LONG count = 0;
+    if (ep && ep->ExceptionRecord && IsFatal(ep->ExceptionRecord->ExceptionCode)) {
+        if (InterlockedIncrement(&count) <= 8)
+            LogException(ep, "first-chance");
+    }
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+inline LONG WINAPI TopLevelHandler(EXCEPTION_POINTERS* ep)
+{
+    LogException(ep, "UNHANDLED/terminal");
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+inline void InstallCrashProbe()
+{
+    DbgFileLogWrite("[CrashProbe] installing handlers...");
+    AddVectoredExceptionHandler(1, VectoredHandler);
+    SetUnhandledExceptionFilter(TopLevelHandler);
+    DbgFileLogWrite("[CrashProbe] handlers installed.");
+}
+
+} // namespace crashprobe

--- a/internal/src/core/runtime/RuntimeOffsets.cpp
+++ b/internal/src/core/runtime/RuntimeOffsets.cpp
@@ -130,10 +130,10 @@ uint32_t PP_IsAccel         = 0x184;
 uint32_t PP_UseAccel        = 0x185;   // 1 byte after IsAccel — adjacent bool pair
 uint32_t PP_VelocityChangeRate = 0x188;
 uint32_t PP_VelocityChangeRateInv = 0x18C;
-uint32_t PP_Magnitude       = 0x194;
-uint32_t PP_Frequency       = 0x198;
-uint32_t PP_Amplitude       = 0x19C;
-uint32_t PP_HasCustomAmplitude = 0x1A0;
+uint32_t PP_Magnitude       = 0x19C;
+uint32_t PP_Frequency       = 0x1A0;
+uint32_t PP_Amplitude       = 0x1A4;
+uint32_t PP_HasCustomAmplitude = 0x1A8;
 uint32_t PP_CollMult              = 0xC0;
 uint32_t PP_TurnRate              = 0xD4;
 uint32_t PP_TurnRateDelay         = 0xD8;
@@ -167,8 +167,8 @@ uint32_t Player_FacingAngle  = 0x22C;
 // BeeByte decoy names ("GuiCanvasSwitcher", "UpdateRadialValue") preserved
 // in IL2CPP metadata; il2cpp_field_get_offset returns runtime-ready values
 // (all parent ACTK shifts already baked into the dump layout).
-uint32_t Gjj_OriginX    = 0x368;  // GuiCanvasSwitcher.x
-uint32_t Gjj_OriginY    = 0x36C;  // GuiCanvasSwitcher.y (= OriginX+4)
+uint32_t Gjj_OriginX    = 0x370;  // ICODPOCLEEL.x (was "GuiCanvasSwitcher" decoy pre-2026-08 build)
+uint32_t Gjj_OriginY    = 0x374;  // ICODPOCLEEL.y (= OriginX+4)
 uint32_t Gjj_DestX      = 0x370;  // IAJJLFBDJGE.x
 uint32_t Gjj_DestY      = 0x374;  // IAJJLFBDJGE.y (= DestX+4)
 uint32_t Gjj_DurationMs = 0x388;  // EAICINLCCJK
@@ -366,10 +366,10 @@ static Entry s_entries[] = {
     { "ProjectileProperties", { "AccelerationInv", "accelerationInv" },   2, 0,     &PP_AccelerationInv, false },
     { "ProjectileProperties", { "VelocityChangeRate", "velocityChangeRate" }, 2, 0, &PP_VelocityChangeRate, false },
     { "ProjectileProperties", { "VelocityChangeRateInv", "velocityChangeRateInv" }, 2, 0, &PP_VelocityChangeRateInv, false },
-    { "ProjectileProperties", { "Magnitude",  "magnitude" },         2, 0,     &PP_Magnitude,       false },
-    { "ProjectileProperties", { "Frequency",  "frequency" },         2, 0,     &PP_Frequency,       false },
-    { "ProjectileProperties", { "Amplitude",  "amplitude" },         2, 0,     &PP_Amplitude,       false },
-    { "ProjectileProperties", { "HasCustomAmplitude","CustomAmplitude","customAmplitude" }, 3, 0, &PP_HasCustomAmplitude, false },
+    { "ProjectileProperties", { "ProjectileMagnitude", "Magnitude",  "magnitude" },  3, 0, &PP_Magnitude,       false },
+    { "ProjectileProperties", { "ProjectileFrequency", "Frequency",  "frequency" },  3, 0, &PP_Frequency,       false },
+    { "ProjectileProperties", { "ProjectileAmplitude", "Amplitude",  "amplitude" },  3, 0, &PP_Amplitude,       false },
+    { "ProjectileProperties", { "IsAmplitudeApplied", "HasCustomAmplitude","CustomAmplitude","customAmplitude" }, 4, 0, &PP_HasCustomAmplitude, false },
     { "ProjectileProperties", { "CollisionMult","collisionMult",
                                  "ConditionEffectAmount" },          3, 0,     &PP_CollMult,        false },
     { "ProjectileProperties", { "ProjectileTurnRate", "TurnRate","turnRate"},     3, 0, &PP_TurnRate,        false },
@@ -377,8 +377,8 @@ static Entry s_entries[] = {
     { "ProjectileProperties", { "ProjectileTurnStopTime", "TurnStopTime" },      2, 0, &PP_TurnStopTime,    false },
     { "ProjectileProperties", { "ProjectileCircleTurnAngle","CircleTurnAngle" }, 2, 0, &PP_CircleTurnAngle, false },
     { "ProjectileProperties", { "ProjectileCircleTurnDelay","CircleTurnDelay" }, 2, 0, &PP_CircleTurnDelay, false },
-    { "ProjectileProperties", { "TurnAcceleration","turnAcceleration" },          2, 0, &PP_TurnAcceleration,false },
-    { "ProjectileProperties", { "TurnAccelerationDelay","turnAccelerationDelay"},2, 0, &PP_TurnAccelDelay,  false },
+    { "ProjectileProperties", { "ProjectileTurnAcceleration", "TurnAcceleration","turnAcceleration" },       3, 0, &PP_TurnAcceleration,false },
+    { "ProjectileProperties", { "ProjectileTurnAccelerationDelay", "TurnAccelerationDelay","turnAccelerationDelay"}, 3, 0, &PP_TurnAccelDelay,  false },
     { "ProjectileProperties", { "TurnClamp","turnClamp","ProjectileTurnClamp" }, 3, 0, &PP_TurnClamp,       false },
     { "ProjectileProperties", { "TurnAccelerationInv","turnAccelerationInv" },   2, 0, &PP_TurnAccelInv,    false },
     { "ProjectileProperties", { "IsTurning",  "isTurning","Turning"},            3, 0, &PP_IsTurning,       false },
@@ -410,7 +410,7 @@ static Entry s_entries[] = {
     // ── GJJCEFJMNMK throwable entity (no extra shift — runtime offsets in dump) ──
     // "GuiCanvasSwitcher" and "IAJJLFBDJGE" are BeeByte field names for origin/dest Vector2.
     // ACTK shift from LKHPPBEGNOM parent is already reflected in the dump layout.
-    { "GJJCEFJMNMK", { "GuiCanvasSwitcher" },                                     1, 0, &Gjj_OriginX,   false },
+    { "GJJCEFJMNMK", { "ICODPOCLEEL", "GuiCanvasSwitcher" },                      2, 0, &Gjj_OriginX,   false },
     { "GJJCEFJMNMK", { "IAJJLFBDJGE" },                                           1, 0, &Gjj_DestX,     false },
     { "GJJCEFJMNMK", { "EAICINLCCJK" },                                           1, 0, &Gjj_DurationMs,false },
 
@@ -692,33 +692,77 @@ bool MapObjectConditionsMakeUntargetable(uint32_t word0, uint32_t word1)
         || HasCondition(full, ConditionEffects::Invulnerable);// bit 24 — permanent immunity
 }
 
+// Guarded single-offset read + strict shape validation. COHCKAPOLCA is always a
+// 1-D UInt32[2]: object header {klass, monitor, bounds==null, max_length==2}.
+// A wrong offset reads some other field (this build: a float 1.0f dereferenced as
+// a pointer → the 0x3F800018 first-chance AVs), which this validation rejects
+// before we trust the data. Returns: 1 = validated array read, 0 = null array at
+// this offset (legit "no conditions"), -1 = not a conditions array / fault.
+static int TryReadCondArrayAt(void* entity, uint32_t off, uint32_t* outW0, uint32_t* outW1)
+{
+    __try {
+        uint8_t* ent = reinterpret_cast<uint8_t*>(entity);
+        void* arr = *reinterpret_cast<void**>(ent + off);
+        if (!arr)
+            return 0;
+        const uintptr_t a = reinterpret_cast<uintptr_t>(arr);
+        if (a < 0x10000 || a > 0x7FFFFFFFFFFFULL || (a & 7) != 0)
+            return -1;
+        uint8_t* ap = reinterpret_cast<uint8_t*>(arr);
+        void*   klass  = *reinterpret_cast<void**>(ap + 0x00);
+        void*   bounds = *reinterpret_cast<void**>(ap + 0x10);
+        int32_t maxLen = *reinterpret_cast<int32_t*>(ap + 0x18);
+        const uintptr_t k = reinterpret_cast<uintptr_t>(klass);
+        if (k < 0x10000 || k > 0x7FFFFFFFFFFFULL || bounds != nullptr || maxLen != 2)
+            return -1;
+        auto* data = reinterpret_cast<uint32_t*>(ap + 0x20);
+        *outW0 = data[0];
+        *outW1 = data[1];
+        return 1;
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        return -1;
+    }
+}
+
 bool TryReadMapObjectConditions(void* mapObjectPtr, uint32_t* outWord0, uint32_t* outWord1)
 {
     if (outWord0) *outWord0 = 0;
     if (outWord1) *outWord1 = 0;
     if (!mapObjectPtr || !outWord0 || !outWord1)
         return false;
-    const uint32_t off = MoConditions;
-    if (off == 0)
+    if (MoConditions == 0)
         return false;
 
-    __try {
-        uint8_t* ent = reinterpret_cast<uint8_t*>(mapObjectPtr);
-        void* arr = *reinterpret_cast<void**>(ent + off);
-        if (!arr)
-            return true;
-        int32_t maxLen = *reinterpret_cast<int32_t*>(reinterpret_cast<uint8_t*>(arr) + 0x18);
-        // COHCKAPOLCA is always exactly UInt32[2]. Reject anything else as garbage/wrong class.
-        if (maxLen != 2)
-            return true;
-        auto* data = reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(arr) + 0x20);
-        *outWord0 = data[0];
-        *outWord1 = data[1];
-        return true;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        *outWord0 = *outWord1 = 0;
-        return false;
+    // ACTK's per-field runtime shuffle keeps moving COHCKAPOLCA relative to its
+    // metadata offset (the fixed +0x50 assumption broke on the 2026-08 build).
+    // Self-locate instead: once a candidate offset yields a validated UInt32[2]
+    // on a live entity, lock it in for the rest of the session.
+    static uint32_t s_lockedOff = 0;   // 0 = not yet locked
+
+    if (s_lockedOff != 0) {
+        const int r = TryReadCondArrayAt(mapObjectPtr, s_lockedOff, outWord0, outWord1);
+        return r >= 0;   // null array at the right offset = "no conditions", still success
     }
+
+    // Candidates around the name-resolved (metadata + kActk) value, most likely
+    // first: as-resolved, ±8, +0x10, and the raw metadata offset (no ACTK shift).
+    const uint32_t base = MoConditions;
+    const uint32_t candidates[6] = {
+        base, base + 8, base - 8, base + 0x10, base - 0x10, base - kActk,
+    };
+    for (int i = 0; i < 6; ++i) {
+        const int r = TryReadCondArrayAt(mapObjectPtr, candidates[i], outWord0, outWord1);
+        if (r == 1) {
+            s_lockedOff = candidates[i];
+            DBG_FILE_LOG("[RuntimeOffsets] MoConditions self-located at 0x" << std::hex
+                << candidates[i] << " (name-resolved was 0x" << base << std::dec << ")");
+            return true;
+        }
+    }
+    // No candidate validated on this entity (its array may just be null) — report
+    // "no conditions" without locking so a later entity with a live array decides.
+    *outWord0 = *outWord1 = 0;
+    return true;
 }
 
 void FormatMapObjectConditionMask(uint32_t word0, uint32_t word1, char* buf, size_t bufSize)

--- a/internal/src/features/control/FeatureCommandRegistry.cpp
+++ b/internal/src/features/control/FeatureCommandRegistry.cpp
@@ -110,6 +110,7 @@ namespace {
             FH_FLOAT("colliderMultiplier", PlayerCollider::SetMultiplier),
             FH("clientDefense", FeatureState::SetClientDefense(static_cast<int32_t>(f.Int()))),
             FH("clientClassType", FeatureState::SetClientClassType(static_cast<int32_t>(f.Int()))),
+            FH("clientSpeed", FeatureState::SetClientSpeed(static_cast<int32_t>(f.Int()))),
             FH_INT("autoDodgeMode", IpcBridge_SetAutoDodgeMode),
             FH_FLOAT("autoDodgeHorizonMs", IpcBridge_SetAutoDodgeHorizonMs),
             FH_FLOAT("autoDodgeHitboxPadding", IpcBridge_SetAutoDodgeHitboxPadding),

--- a/internal/src/features/control/FeatureState.cpp
+++ b/internal/src/features/control/FeatureState.cpp
@@ -31,6 +31,9 @@ static std::atomic<int> s_featSkinOverrideEnabled{0}, s_featSkinOverrideId{0};
 static std::atomic<float> s_featDodgeHorizonMs{800.f}, s_featDodgeHitboxPadding{0.f}, s_featAutoAbilityMpPct{0.f};
 static std::atomic<float> s_featWalkTargetX{0.f}, s_featWalkTargetY{0.f}, s_featCameraZoomValue{8.f};
 static std::atomic<int32_t> s_featClientDefense{static_cast<int32_t>(0x80000000u)}, s_featClientClassType{0};
+// Total SPD stat (base + bonus) pushed from the client's NEWTICK — server-
+// authoritative, name/offset independent. -1 = unset (DLL uses its own fallback).
+static std::atomic<int32_t> s_featClientSpeed{-1};
 
 namespace FeatureState {
 
@@ -81,6 +84,8 @@ void    SetSkinOverride(bool enabled, int skinId)   { s_featSkinOverrideEnabled.
 
 int32_t GetClientDefense()                          { return s_featClientDefense.load(std::memory_order_relaxed); }
 void    SetClientDefense(int32_t defense)           { s_featClientDefense.store(defense, std::memory_order_relaxed); }
+int32_t GetClientSpeed()                            { return s_featClientSpeed.load(std::memory_order_relaxed); }
+void    SetClientSpeed(int32_t speed)               { s_featClientSpeed.store(speed, std::memory_order_relaxed); }
 int32_t GetClientClassType()                        { return s_featClientClassType.load(std::memory_order_relaxed); }
 void    SetClientClassType(int32_t classType)       { s_featClientClassType.store(classType, std::memory_order_relaxed); }
 

--- a/internal/src/features/control/FeatureState.h
+++ b/internal/src/features/control/FeatureState.h
@@ -56,6 +56,8 @@ void    SetSkinOverride(bool enabled, int skinId);
 
 int32_t GetClientDefense();
 void    SetClientDefense(int32_t defense);
+int32_t GetClientSpeed();               // total SPD stat, -1 = unset
+void    SetClientSpeed(int32_t speed);
 int32_t GetClientClassType();
 void    SetClientClassType(int32_t classType);
 

--- a/internal/src/features/movement/dodge/AoeTracking.cpp
+++ b/internal/src/features/movement/dodge/AoeTracking.cpp
@@ -102,6 +102,7 @@ static inline void AgentLogAoe(const char* hypothesisId, const char* location, c
     const std::string& dataJsonObject)
 {
 #ifdef _DEBUG
+#pragma warning(suppress:4996)   // getenv is fine here; Debug SDL checks flag it as C4996
     static const char* kLogPath = std::getenv("RE_AOE_DEBUG_LOG");
     if (!kLogPath || !*kLogPath) return;
     std::ofstream f(kLogPath, std::ios::app | std::ios::binary);

--- a/internal/src/features/movement/dodge/DangerPlanner.cpp
+++ b/internal/src/features/movement/dodge/DangerPlanner.cpp
@@ -1,6 +1,7 @@
 #include "pch-il2cpp.h"
 #include "DangerPlanner.h"
 #include "DodgeGeometry.h"
+#include "MovementRuntime.h"
 #include "XDodge.h"
 #include "RolloutDodge.h"
 #include "ZDodge.h"
@@ -191,11 +192,29 @@ float GetMoveSpeedMul(void* player)
 
 bool CallMoveTo(void* player, float x, float y)
 {
-    if (!s_fnMoveTo || !player) return false;
-    bool ok = false;
-    __try { ok = s_fnMoveTo(player, x, y, nullptr); }
-    __except (EXCEPTION_EXECUTE_HANDLER) { ok = false; }
-    return ok;
+    if (!player) return false;
+    // One-shot probe: log the ACTUAL runtime class of the player object.
+    // DGLCONCOIBO (MoveTo) is virtual; DodgeRuntime::CallMoveTo re-dispatches
+    // through the object's vtable, and this line confirms what class it saw.
+    static volatile LONG s_logN = 0;
+    if (InterlockedIncrement(&s_logN) == 1) {
+        __try {
+            Il2CppClass* c = il2cpp_object_get_class(reinterpret_cast<Il2CppObject*>(player));
+            const char* cn = c ? il2cpp_class_get_name(c) : "(nullcls)";
+            const char* ns = c ? il2cpp_class_get_namespace(c) : "";
+            char buf[256];
+            snprintf(buf, sizeof(buf),
+                     "[Dodge] CallMoveTo: live player class = %s::%s",
+                     (ns && *ns) ? ns : "<g>", cn ? cn : "?");
+            DbgFileLogWrite(buf);
+        } __except (EXCEPTION_EXECUTE_HANDLER) {
+            DbgFileLogWrite("[Dodge] CallMoveTo: class lookup faulted");
+        }
+    }
+    // Single MoveTo path for all dodge engines: virtual-dispatch aware,
+    // SEH-guarded, resolved by name (see MovementRuntime.cpp).
+    DodgeRuntime::EnsureResolved();
+    return DodgeRuntime::CallMoveTo(player, x, y);
 }
 
 // (Removed) InjectMoveInput — writing MoveDirX/Y/Moving does nothing
@@ -708,10 +727,12 @@ UpdateFn s_origUpdate = nullptr;
 void*    s_hookTarget = nullptr;
 bool     s_hookInstalled = false;
 
-void __fastcall Detour_AppEngineUpdate(void* __this, void* method)
+// Dodge sensor/planner work for one frame. Extracted from the detour so the
+// detour can run it under SEH (see DodgeTickGuarded) without tripping C2712 —
+// this body legitimately holds C++ temporaries (ostringstream via DBG_FILE_LOG),
+// which a __try scope in the same function cannot unwind.
+static void RunDodgeTickBody()
 {
-    if (s_origUpdate) s_origUpdate(__this, method);
-
     // Two dodge engines run from this hook (mutually exclusive): XDodge
     // (spacetime BFS/A*) and RolloutDodge (forward input-simulation). They
     // share the preamble, goal plumbing, and GhostHit safety net below.
@@ -773,6 +794,29 @@ void __fastcall Detour_AppEngineUpdate(void* __this, void* method)
         GhostHit::Tick(p, px, py);
         return;
     }
+}
+
+// SEH firewall around the dodge frame. A stale-offset sensor read (documented
+// in the body above) or any other fault inside dodge must not take down the
+// game process: swallow it, log once per ~240 frames, and let the game keep
+// running. The __except handler uses only the plain DbgFileLogWrite (no C++
+// temporaries) so this function has nothing to unwind (avoids C2712).
+static void DodgeTickGuarded()
+{
+    __try {
+        RunDodgeTickBody();
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        static volatile LONG s_ex = 0;
+        if ((InterlockedIncrement(&s_ex) % 240) == 1)
+            DbgFileLogWrite("[Dodge] detour: SEH caught a fault in dodge tick — "
+                            "frame skipped (stale entity/projectile offset?)");
+    }
+}
+
+void __fastcall Detour_AppEngineUpdate(void* __this, void* method)
+{
+    if (s_origUpdate) s_origUpdate(__this, method);
+    DodgeTickGuarded();
 }
 
 } // namespace

--- a/internal/src/features/movement/dodge/MovementRuntime.cpp
+++ b/internal/src/features/movement/dodge/MovementRuntime.cpp
@@ -2,8 +2,12 @@
 #include "MovementRuntime.h"
 
 #include "Il2CppResolver.h"
+#include "DbgFileLog.h"
+#include "features/control/FeatureState.h"
 
+#include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <windows.h>
 
 namespace {
@@ -13,6 +17,7 @@ using CalcMoveSpeedFn = float(__fastcall*)(void* __this, void* methodInfo);
 using GetDeltaTimeFn = float(__cdecl*)(void* method);
 
 MoveToFn s_fnMoveTo = nullptr;
+const MethodInfo* s_miMoveTo = nullptr;
 CalcMoveSpeedFn s_fnCalcMoveSpeed = nullptr;
 GetDeltaTimeFn s_fnGetDeltaTime = nullptr;
 bool s_moveResolved = false;
@@ -29,8 +34,51 @@ void ResolveMoveTo()
         const MethodInfo* mi = il2cpp_class_get_method_from_name(klass, "DGLCONCOIBO", 2);
         if (!mi || !mi->methodPointer) return;
         s_fnMoveTo = reinterpret_cast<MoveToFn>(mi->methodPointer);
+        s_miMoveTo = mi;
         s_moveResolved = true;
     });
+}
+
+// DGLCONCOIBO (MoveTo) is virtual — the live player can be a FKALGHJIADI
+// subclass whose override differs from the impl we bound at resolve time.
+// Re-dispatch through the object's own vtable, caching per live class so the
+// il2cpp lookup runs once per class, not per frame. Falls back to the bound
+// FKALGHJIADI impl if anything about the lookup is off.
+MoveToFn ResolveMoveToForObject(void* player)
+{
+    static void*    s_cachedKlass = nullptr;
+    static MoveToFn s_cachedFn    = nullptr;
+
+    if (!s_miMoveTo) return s_fnMoveTo;
+    void* klass = nullptr;
+    __try { klass = *reinterpret_cast<void**>(player); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return s_fnMoveTo; }
+    if (!klass) return s_fnMoveTo;
+    if (klass == s_cachedKlass && s_cachedFn) return s_cachedFn;
+
+    MoveToFn fn = s_fnMoveTo;
+    __try {
+        const MethodInfo* mi = il2cpp_object_get_virtual_method(
+            reinterpret_cast<Il2CppObject*>(player), s_miMoveTo);
+        if (mi && mi->methodPointer)
+            fn = reinterpret_cast<MoveToFn>(mi->methodPointer);
+    } __except (EXCEPTION_EXECUTE_HANDLER) { fn = s_fnMoveTo; }
+
+    s_cachedKlass = klass;
+    s_cachedFn    = fn;
+    return fn;
+}
+
+// Raw CalcMoveSpeed (FKALGHJIADI::GCFKGLKAPND) call, SEH-guarded. Returns
+// <= 0 on failure so the caller can distinguish "unresolved" from a value.
+float CallCalcMoveSpeedRaw(void* player)
+{
+    if (!s_fnCalcMoveSpeed || !player) return 0.f;
+    float v = 0.f;
+    __try { v = s_fnCalcMoveSpeed(player, nullptr); }
+    __except (EXCEPTION_EXECUTE_HANDLER) { return 0.f; }
+    if (!std::isfinite(v) || v <= 0.f) return 0.f;
+    return v;
 }
 
 void ResolveCalcMoveSpeed()
@@ -101,13 +149,50 @@ float GetMoveSpeedMul(void* player)
 bool CallMoveTo(void* player, float x, float y)
 {
     if (!s_fnMoveTo || !player) return false;
+    MoveToFn fn = ResolveMoveToForObject(player);
+    if (!fn) return false;
     bool ok = false;
     __try {
-        ok = s_fnMoveTo(player, x, y, nullptr);
+        ok = fn(player, x, y, nullptr);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         ok = false;
     }
     return ok;
+}
+
+float GetTilesPerSec(void* player)
+{
+    // Server-authoritative SPD stat, pushed each NEWTICK from the client
+    // (FeatureState::clientSpeed). This is name/offset independent — the old
+    // in-DLL read at player+0x478 broke on the 2026-08 layout shift, and the
+    // game's CalcMoveSpeed (GCFKGLKAPND) returns a ~1.0 MULTIPLIER, not tiles/s.
+    const int32_t clientSpd = FeatureState::GetClientSpeed();
+    if (clientSpd >= 0) {
+        // Flash speed curve, capped at SPD 75 (rings/pets past 75 don't add
+        // server-authorized movement, so extrapolating rubber-bands).
+        const float spd = std::clamp(static_cast<float>(clientSpd), 0.f, 75.f);
+        float tps = 4.0f + 5.6f * (spd / 75.0f);
+
+        // Refine with the game's own live multiplier (Speedy / Slowed / tile
+        // speed), which the flat curve can't see. ~1.0 in the common case.
+        ResolveCalcMoveSpeed();
+        const float mul = CallCalcMoveSpeedRaw(player);
+        if (mul > 0.2f && mul < 5.f) tps *= mul;
+
+        static bool s_logged = false;
+        if (!s_logged) {
+            s_logged = true;
+            char buf[160];
+            snprintf(buf, sizeof(buf),
+                     "[DodgeRuntime] clientSpd=%d mul=%.3f -> tilesPerSec=%.3f",
+                     clientSpd, mul, tps);
+            DbgFileLogWrite(buf);
+        }
+        if (tps < 0.5f || tps > 40.f) return 0.f;
+        return tps;
+    }
+    // clientSpeed not yet pushed (auto-aim plugin off or pre-first-NEWTICK).
+    return 0.f;   // caller applies its own SPD-50 fallback
 }
 
 void Reset()

--- a/internal/src/features/movement/dodge/MovementRuntime.h
+++ b/internal/src/features/movement/dodge/MovementRuntime.h
@@ -5,6 +5,10 @@ namespace DodgeRuntime {
 bool  EnsureResolved();
 float GetDeltaTime();
 float GetMoveSpeedMul(void* player);
+// Move budget in tiles/sec from the game's own CalcMoveSpeed
+// (FKALGHJIADI::GCFKGLKAPND, name-stable across builds).
+// Returns 0 when unresolved/implausible — apply your own fallback.
+float GetTilesPerSec(void* player);
 bool  CallMoveTo(void* player, float x, float y);
 void  Reset();
 

--- a/internal/src/gui/tabs/TestTAB.cpp
+++ b/internal/src/gui/tabs/TestTAB.cpp
@@ -1,6 +1,7 @@
 #include "pch-il2cpp.h"
 #include "TestTAB.h"
 #include "DangerPlanner.h"
+#include "MovementRuntime.h"
 #include "ProjectileCatalog.h"
 #include "XDodge.h"
 #include "RolloutDodge.h"
@@ -474,17 +475,20 @@ static void ReadPlayerStats(int32_t& hp, int32_t& maxHp, float& spd, float& tile
     if (!lp) return;
     __try { hp    = *(int32_t*)((uint8_t*)lp + RuntimeOffsets::HP);    } __except(EXCEPTION_EXECUTE_HANDLER) {}
     __try { maxHp = *(int32_t*)((uint8_t*)lp + RuntimeOffsets::MaxHP); } __except(EXCEPTION_EXECUTE_HANDLER) {}
-    __try { spd   = *(float*)((uint8_t*)lp + 0x478);   } __except(EXCEPTION_EXECUTE_HANDLER) {}
-    if (spd > 0.f && spd <= 120.f) {
-        // Flash caps speed scaling at SPD=75 — stats above that from
-        // rings/pet/totems don't give additional in-game movement. We
-        // were extrapolating linearly past 75, producing a tilesPerSec
-        // the server refuses to authorize. Clamp before the curve so
-        // our move budget matches server-authoritative walk speed and
-        // the planner stops rubber-banding on high-SPD characters.
-        const float effSpd = (spd > 75.f) ? 75.f : spd;
-        tilesPerSec = 4.0f + 5.6f * (effSpd / 75.0f);
+    // Move budget from the game's own CalcMoveSpeed (name-stable GCFKGLKAPND).
+    // The old raw read at player+0x478 landed on a pointer field after the
+    // 2026-08 layout shift, failed the 0<spd<=120 guard, left tilesPerSec at 0,
+    // and PJDodgeCore's `c.speed <= 0` gate silently disabled every dodge.
+    tilesPerSec = DodgeRuntime::GetTilesPerSec(lp);
+    if (tilesPerSec <= 0.f) {
+        // Unresolved (e.g. first frames in world): assume SPD 50 so the dodge
+        // planner always has a non-zero move budget. Server-authoritative
+        // clamping tolerates a modest under/over-estimate.
+        tilesPerSec = 4.0f + 5.6f * (50.f / 75.f);
     }
+    // Display-equivalent SPD stat back-derived from the speed curve
+    // (Flash: tilesPerSec = 4.0 + 5.6 * spd/75, capped at SPD 75).
+    spd = std::clamp((tilesPerSec - 4.0f) / 5.6f * 75.f, 0.f, 120.f);
 }
 
 
@@ -501,14 +505,12 @@ static void MovePlayer(float targetWorldX, float targetWorldY, float dt,
 
     if (mag < 0.01f) return;
 
-    // Read SPD stat (+0x478) for step budget
-    float spd = 50.f;
-    __try {
-        float s = *(float*)((uint8_t*)player + 0x478);
-        if (s > 0.f && s <= 120.f) spd = s;
-    } __except (EXCEPTION_EXECUTE_HANDLER) {}
+    // Step budget from the game's own CalcMoveSpeed; SPD-50 curve fallback
+    // when unresolved. (The old raw +0x478 SPD read broke on the 2026-08 build.)
+    float tps = DodgeRuntime::GetTilesPerSec(player);
+    if (tps <= 0.f) tps = 4.f + 5.6f * (50.f / 75.f);
 
-    float maxStep = (4.f + 5.6f * (spd / 75.f)) * dt * speedMult;
+    float maxStep = tps * dt * speedMult;
 
     {
         float tileSpd = WorldTAB::GetTileSpeed(

--- a/internal/src/gui/tabs/WorldTAB.cpp
+++ b/internal/src/gui/tabs/WorldTAB.cpp
@@ -2391,7 +2391,15 @@ namespace WorldTAB {
     using SquareLookupFn = void* (__fastcall*)(void* map, int tx, int ty, void* methodInfo);
     static SquareLookupFn s_squareLookup = nullptr;
     static bool s_liveHazResolved = false;
-    static bool s_liveHazOk = true;
+    // DISABLED: kSquareLookupRva below is a hardcoded, reverse-engineered address
+    // that is game-version-specific. On the current build it is STALE (RVAs shifted)
+    // and points into the wrong function; calling it corrupts the stack, which the
+    // QuerySquareHazard __except CANNOT catch (unwind-unhandleable) — so the 8-fail
+    // self-disable never triggers and the process hard-crashes instead. Default OFF
+    // so we always use the cached IsDamagingTile fallback (the comment below calls it
+    // "== current behaviour"). Re-enable only after re-deriving kSquareLookupRva +
+    // kSquareDamageOff/kSquareCoverOff for the running build via disassembly.
+    static bool s_liveHazOk = false;
     static int  s_liveHazFails = 0;
     static constexpr uintptr_t kSquareLookupRva = 0x1CA7B60;
     static constexpr uint32_t  kSquareDamageOff = 0x58;   // i32 ground damage


### PR DESCRIPTION
Auto-dodge ran every frame but never moved the player. Root cause was the move budget, not sensing: the SPD read at player+0x478 landed on a pointer field after the 2026-08 il2cpp layout shift, so tilesPerSec came back 0 and PJDodgeCore's `c.speed <= 0` gate silently declined every dodge. Verified in-game after the fix .

Changes:
- Move budget (server-authoritative SPD): the client now pushes `clientSpeed` (playerData.speed + speedBonus) over IPC each NEWTICK; the DLL converts it to tiles/sec via the Flash curve 4 + 5.6*min(spd,75)/75, refined by the live CalcMoveSpeed multiplier. Name/offset independent, so it survives layout shifts. (auto-aim.ts, FeatureState, FeatureCommandRegistry, MovementRuntime, TestTAB). Note: GCFKGLKAPND/CalcMoveSpeed returns a ~1.0 MULTIPLIER, not tiles/sec — the old code misread it.
- MoveTo hardening: DGLCONCOIBO (MoveTo) is virtual; CallMoveTo now re-dispatches through the live object's vtable (cached per class) instead of the hardcoded FKALGHJIADI impl (MovementRuntime, DangerPlanner). All engines route through this (NativeMoveTo -> CallMoveTo -> DodgeRuntime::CallMoveTo).
- RuntimeOffsets: fixed the ProjectileProperties fields renamed this build (Magnitude->ProjectileMagnitude, Frequency, Amplitude, TurnAcceleration/Delay, HasCustomAmplitude->IsAmplitudeApplied) so bullet prediction works, plus the AoE throwable origin (GuiCanvasSwitcher->ICODPOCLEEL). Rewrote TryReadMapObjectConditions as a self-locating probe (the fixed +0x50 ACTK assumption broke on this build, causing SEH-caught AVs at load).
- Nexus crash fix kept: WorldTAB::IsTileDamagingLive no longer calls a game fn via a stale hardcoded RVA (defaults to the cached fallback).
- Build: il2cpp-appdata.h drops manual Il2CppGCHandle/Il2CppAndroidUpStateFunc typedefs now emitted by the regenerated headers; AoeTracking.cpp getenv gets a #pragma warning(suppress:4996) so the Debug SDL build compiles.
- CrashProbe (core/logging/CrashProbe.h, installed in main.cpp) logs faulting module+offset+backtrace — kept as a permanent diagnostic.
